### PR TITLE
Avoid lang redirects [Fixes #32]

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -117,7 +117,7 @@ module.exports = {
         // language file path
         defaultLanguage,
         // redirect to `/en/` when connecting `/`
-        redirect: true,
+        redirect: false,
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality


### PR DESCRIPTION
## Description

Our internationalization plugin was [redirecting traffic based on the user's browser preference](https://github.com/wiziple/gatsby-plugin-intl#how-it-works). This led to issues of redirecting users to pages that did not exist (e.g. someone with browser language set to Spanish landing on esp.ethereum.foundation/ was being redirected to esp.ethereum.foundation/es/, which does not exist).

The reason this was an issue is because the only page we actually have translated into Spanish is https://esp.ethereum.foundation/es/local-grants/honduras/ 

## Related Issue
#32
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->