### PR TITLE
Add canonical tags

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,13 +1,16 @@
-const supportedLanguages = [`en`, `es`]
+const translations = require("./src/utils/translations")
+
+const supportedLanguages = translations.supportedLanguages
 const defaultLanguage = `en`
+const siteUrl = `https://esp.ethereum.foundation`
 
 module.exports = {
   siteMetadata: {
     // `title` & `description` pulls from respective ${lang}.json files in PageMetadata.js
     title: `Ethereum Ecosystem Support Program`,
     description: `The Ethereum Ecosystem Support Program provides financial and non-financial support for projects working to accelerate the growth of Ethereum.`,
-    url: "https://esp.ethereum.foundation",
-    siteUrl: "https://esp.ethereum.foundation", // sitemap
+    url: siteUrl,
+    siteUrl, // for sitemap generation
     author: `@EF_ESP`,
     image:
       "https://user-images.githubusercontent.com/8097623/69177629-c137a400-0abc-11ea-9bcd-da3ba03d2688.png",
@@ -17,6 +20,12 @@ module.exports = {
   plugins: [
     `gatsby-plugin-styled-components`,
     `gatsby-plugin-react-helmet`,
+    {
+      resolve: `gatsby-plugin-react-helmet-canonical-urls`,
+      options: {
+        siteUrl,
+      },
+    },
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gatsby-plugin-manifest": "^2.2.27",
     "gatsby-plugin-offline": "^3.0.19",
     "gatsby-plugin-react-helmet": "^3.1.14",
+    "gatsby-plugin-react-helmet-canonical-urls": "^1.4.0",
     "gatsby-plugin-sharp": "^2.2.37",
     "gatsby-plugin-sitemap": "^2.4.2",
     "gatsby-plugin-styled-components": "^3.1.18",
@@ -54,6 +55,7 @@
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "yarn develop",
+    "start:static": "gatsby build && gatsby serve",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },

--- a/src/components/PageMetadata.js
+++ b/src/components/PageMetadata.js
@@ -3,8 +3,9 @@ import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
+import { Location } from "@reach/router"
 
-import { getDefaultMessage } from "../utils/translations"
+import { getDefaultMessage, supportedLanguages } from "../utils/translations"
 
 const PageMetadata = ({ description, meta, title }) => {
   const { site } = useStaticQuery(
@@ -36,61 +37,78 @@ const PageMetadata = ({ description, meta, title }) => {
   })
 
   return (
-    <Helmet
-      htmlAttributes={{ lang: intl.locale }}
-      title={title}
-      titleTemplate={`%s | ${siteTitle}`}
-      meta={[
-        {
-          name: `description`,
-          content: desc,
-        },
-        {
-          name: `image`,
-          content: site.siteMetadata.image,
-        },
-        {
-          property: `og:title`,
-          content: title,
-        },
-        {
-          property: `og:description`,
-          content: desc,
-        },
-        {
-          property: `og:type`,
-          content: `website`,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary`,
-        },
-        {
-          name: `twitter:creator`,
-          content: site.siteMetadata.author,
-        },
-        {
-          name: `twitter:site`,
-          content: site.siteMetadata.author,
-        },
-        {
-          name: `twitter:title`,
-          content: title,
-        },
-        {
-          name: `twitter:description`,
-          content: desc,
-        },
-        {
-          property: `og:url`,
-          content: site.siteMetadata.url,
-        },
-        {
-          property: `og:image`,
-          content: site.siteMetadata.image,
-        },
-      ].concat(meta)}
-    />
+    <Location>
+      {({ location }) => {
+        {/* Set canonocial URL to use language path to avoid duplicate content */}
+        {/* e.g. set esp.ethereum.foundation/about/ to esp.ethereum.foundation/en/about/ */}
+        const { pathname } = location
+        let canonicalPath = pathname
+        const firstDirectory = canonicalPath.split("/")[1]
+        if (!supportedLanguages.includes(firstDirectory)) {
+          canonicalPath = `/en${pathname}`
+        }
+        const canonical = `${site.siteMetadata.url}${canonicalPath}`
+
+        return (
+          <Helmet
+            htmlAttributes={{ lang: intl.locale }}
+            title={title}
+            titleTemplate={`%s | ${siteTitle}`}
+            link={[{ rel: "canonical", key: canonical, href: canonical }]}
+            meta={[
+              {
+                name: `description`,
+                content: desc,
+              },
+              {
+                name: `image`,
+                content: site.siteMetadata.image,
+              },
+              {
+                property: `og:title`,
+                content: title,
+              },
+              {
+                property: `og:description`,
+                content: desc,
+              },
+              {
+                property: `og:type`,
+                content: `website`,
+              },
+              {
+                name: `twitter:card`,
+                content: `summary`,
+              },
+              {
+                name: `twitter:creator`,
+                content: site.siteMetadata.author,
+              },
+              {
+                name: `twitter:site`,
+                content: site.siteMetadata.author,
+              },
+              {
+                name: `twitter:title`,
+                content: title,
+              },
+              {
+                name: `twitter:description`,
+                content: desc,
+              },
+              {
+                property: `og:url`,
+                content: site.siteMetadata.url,
+              },
+              {
+                property: `og:image`,
+                content: site.siteMetadata.image,
+              },
+            ].concat(meta)}
+          />
+        )
+      }}
+    </Location>
   )
 }
 

--- a/src/utils/translations.js
+++ b/src/utils/translations.js
@@ -1,5 +1,7 @@
 const defaultStrings = require("../intl/en.json")
 
+const supportedLanguages = [`en`, `es`]
+
 // Splits key strings to access nested JSON objects
 const resolve = (path, obj) => {
   return path.split(".").reduce((prev, curr) => {
@@ -20,3 +22,4 @@ const getDefaultMessage = key => {
 
 // Must export using ES5 to import in gatsby-node.js
 module.exports.getDefaultMessage = getDefaultMessage
+module.exports.supportedLanguages = supportedLanguages

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,6 +793,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.3.1":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
@@ -5728,6 +5735,13 @@ gatsby-plugin-page-creator@^2.1.38:
     glob "^7.1.6"
     lodash "^4.17.15"
     micromatch "^3.1.10"
+
+gatsby-plugin-react-helmet-canonical-urls@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet-canonical-urls/-/gatsby-plugin-react-helmet-canonical-urls-1.4.0.tgz#9a0f3a6e75b0ff54c6a8e70c2bc48219903a8296"
+  integrity sha512-5g2eqFNh8GSCTvL25sNm84IJ6G79qKHSnOa9druxBj6x5Iw3EujZMv6I4nGMlW5EZlaSf9D5QHNGypUW6idPTg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
 
 gatsby-plugin-react-helmet@^3.1.14:
   version "3.1.21"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To fix #32 I had to remove the redirect functionality of [our internationalization plugin](https://github.com/wiziple/gatsby-plugin-intl). This resulted in both the base paths & English paths resolving as English (e.g. both https://esp.ethereum.foundation/about/ & https://esp.ethereum.foundation/en/about/), which creates a duplicate content issue.

This PR adds a [canonical tag](https://support.google.com/webmasters/answer/139066?hl=en) to every page, specifying the appropriate language path (e.g. so the canonical tag on https://esp.ethereum.foundation/about/ is set to https://esp.ethereum.foundation/en/about/).

## Related Issue
#32 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
