### PR TITLE
Adds Divider component to static template

### DIFF
--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -159,6 +159,12 @@ const Header4 = styled.h4`
   }
 `
 
+const Divider = styled.div`
+  height: 3px;
+  background-image: linear-gradient(to right, #ffcf47, #c6566c);
+  margin: 2rem 0;
+`
+
 // Passing components to MDXProvider allows use across all .md/.mdx files
 // https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#mdxprovider
 const components = {
@@ -170,6 +176,7 @@ const components = {
   LocalGrantsForm,
   RollupGrantsForm,
   ExpandableCard,
+  Divider,
 }
 
 const HeroImg = styled(Img)`


### PR DESCRIPTION
## Description
Adds in a `Divider` component. This was utilized in the RollupGrantsForm markdown, but the component did not exist. Added using footer divider as style guide.

## Related Issue:
![image](https://user-images.githubusercontent.com/54227730/110395892-d58e1000-8023-11eb-90ae-a05c189d07b0.png)
