### PR TITLE
Import "@fortawesome/fontawesome-svg-core/styles.css" [Fixes #82]

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons"
 import styled from "styled-components"
 import { FormattedMessage, injectIntl } from "gatsby-plugin-intl"
+import "@fortawesome/fontawesome-svg-core/styles.css"
 
 import Link from "../components/Link"
 import PageMetadata from "../components/PageMetadata"


### PR DESCRIPTION
## Description
Adds `import "@fortawesome/fontawesome-svg-core/styles.css"` to `src/pages/index.js` alleviating the flickering arrow icon glitch when the page loads. 

## Related Issue #82 
