### PR TITLE
Remove rollup grant form

### DIFF
--- a/src/pages/grants.js
+++ b/src/pages/grants.js
@@ -103,15 +103,6 @@ const GrantsPage = () => {
             with input from technical advisors before a funding decision is
             made.
           </p>
-          <H2>Open Call: Rollup Community Grants</H2>
-          <p>
-            We are currently accepting proposals to grow the rollup community
-            and help kickstart a flourishing rollup ecosystem. Submissions are
-            open through April 16th, 2021.
-          </p>
-          <ButtonContainer>
-            <ButtonLink to="/rollup-grants/">See details</ButtonLink>
-          </ButtonContainer>
           <H2>More Information</H2>
           <p>
             You can find detailed information on the inquiry and grant

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -153,13 +153,6 @@ const IndexPage = ({ intl }) => {
                 <FormattedMessage id="page-home.p-2" />
               </p>
             </Section>
-            {intl.locale === "en" && (
-              <RollupsCallout>
-                The Ethereum Foundation is sponsoring a wave of rollup community
-                grants. Proposals are due April 16th, 2021.{" "}
-                <Link to="/rollup-grants/">See details.</Link>
-              </RollupsCallout>
-            )}
             <H2 id="contact">
               <FormattedMessage id="page-home.contact-us" />
             </H2>

--- a/src/pages/rollup-grants/en.md
+++ b/src/pages/rollup-grants/en.md
@@ -8,11 +8,11 @@ imgAlt: "ESP Rollup Grants image"
 
 # Rollup Community Grants {#rollup-community-grants}
 
-_The Ethereum Foundation is sponsoring a wave of rollup community grants. Proposals are due April 16th 2021. Here are all the details you need._
-
 <Divider />
 
 > 🚨 **The deadline for submission has passed. Stay tuned for updates.**
+
+> [What if I missed the dealine?](#what-if-i-miss-deadline)
 
 <Divider />
 
@@ -32,26 +32,9 @@ Here some links to dive deeper:
 - Learn the basics on [Ethhub](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/optimistic_rollups/)
 - [An Incomplete Guide to Rollups](https://vitalik.ca/general/2021/01/05/rollup.html) by Vitalik.
 
-## Submit proposal {#submit-proposal}
+### Proposal deadline {#deadline}
 
-Anyone is free to participate (individuals and teams) in this grants round.
-
-If you want to submit something but need some inspiration, check out the [wishlist below](#wishlist).
-
-Ideas and projects at any stage of development are welcome:
-
-- Idea phase.
-- Proof of concept.
-- Work in progress.
-- Fleshed out project.
-
-Grants are decided on a case-by-case basis and you may enter more than one proposal! So long as each proposal is unique and meets the requirements.
-
-<RollupGrantsForm />
-
-### Deadline {#deadline}
-
-The deadline for proposals is any time the day of April 16th 2021. We will follow-up with you about your submission by email.
+The deadline for proposals was April 16th 2021. Grants are decided on a case-by-base basis, and we will follow-up with you about your submission by email.
 
 ### Requirements {#requirements}
 

--- a/src/pages/rollup-grants/en.md
+++ b/src/pages/rollup-grants/en.md
@@ -36,6 +36,8 @@ Here some links to dive deeper:
 
 The deadline for proposals was April 16th 2021. Grants are decided on a case-by-base basis, and we will follow-up with you about your submission by email.
 
+Interested in applying for a grant? You can still [inquire](/inquire/) through our general form.
+
 ### Requirements {#requirements}
 
 - Proposals must be in English.


### PR DESCRIPTION
- Removes form from `rollup-grants` page
- Removes links/references to this page
- Leaves the markdown page to avoid breaking any existing external links
- Updates copy on this page to indicate past tense now that deadline has passed
