### PR TITLE
chore: disable focus outline for non-keyboard interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@fontsource/libre-franklin": "^4.5.0",
+    "focus-visible": "^5.2.0",
     "framer-motion": "^4",
     "next": "12.0.7",
     "react": "17.0.2",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { Layout } from '../components/layout';
 import theme from '../theme';
 
 import '../global.css';
+import 'focus-visible/dist/focus-visible';
 import '@fontsource/libre-franklin/200.css';
 import '@fontsource/libre-franklin/300.css';
 import '@fontsource/libre-franklin/400.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,6 +2179,11 @@ focus-lock@^0.9.1:
   dependencies:
     tslib "^2.0.3"
 
+focus-visible@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
+  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
+
 foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"


### PR DESCRIPTION
This PR removes the focus outline from clickable components (i.e.: accordion items, tabs) for non-keyboard interactions.

![Image 2022-01-07 at 9 46 30 AM](https://user-images.githubusercontent.com/948922/148603364-c54a9ec6-0c07-4684-90ed-eed0a8637c80.jpg)

## Description

- removes the focus outline for non-keyboard interactions (click focus)
- preserves the outline for keyboard navigation on keyboard focus, [required for a11y](https://github.com/chakra-ui/chakra-ui/issues/708#issuecomment-628131464)
