### PR TITLE
fix: remove trimming from repeatApplicant value

### DIFF
--- a/src/pages/api/small-grants/project.ts
+++ b/src/pages/api/small-grants/project.ts
@@ -69,7 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         Is_it_Open_Source__c: Is_it_Open_Source__c.trim(),
         Sustainability_Plan__c: Sustainability_Plan__c.trim(),
         Other_Projects__c: Other_Projects__c.trim(),
-        Repeat_Applicant__c: Repeat_Applicant__c.trim(),
+        Repeat_Applicant__c,
         Progress__c: Progress__c.trim(),
         Other_Funding__c: Other_Funding__c.trim(),
         Additional_Information__c: Additional_Information__c.trim(),


### PR DESCRIPTION
This PR removes `trim()` from the `repeatApplicant` value, which is a boolean, causing the `Small Grants` submission to fail
