### PR TITLE
Update pg file size limit

### DIFF
--- a/src/components/forms/ProjectGrantsForm.tsx
+++ b/src/components/forms/ProjectGrantsForm.tsx
@@ -916,7 +916,7 @@ export const ProjectGrantsForm: FC = () => {
                       {selectedFile && errors?.uploadProposal && (
                         <Box mt={1}>
                           <PageText as='small' fontSize='helpText' color='red.500'>
-                            File size cannot exceed 2GB.
+                            File size cannot exceed 4mb.
                           </PageText>
                         </Box>
                       )}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -135,8 +135,8 @@ export const API_NEWSLETTER_SIGNUP_URL = '/api/newsletter-signup';
 // grants list
 export const CURRENT_GRANTS_QUARTERS = ['3', '4'];
 
-// proposal upload
-export const MAX_PROPOSAL_FILE_SIZE = 2147483648;
+// proposal upload file size limit (4mb)
+export const MAX_PROPOSAL_FILE_SIZE = 4194304;
 
 // toast options
 export const TOAST_OPTIONS: UseToastOptions = {

--- a/src/pages/api/project-grants.ts
+++ b/src/pages/api/project-grants.ts
@@ -110,3 +110,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     );
   });
 }
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '4mb'
+    }
+  }
+};


### PR DESCRIPTION
This PR updates the file size limit for Project Grants (currently set to 1mb) to the [maximum of 4mb](https://nextjs.org/docs/messages/api-routes-body-size-limit)
