### PR TITLE
Add grantee page redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -129,11 +129,15 @@
 # Special cases where we can't use the * operator because it generates an
 # infinite loop of redirects
 
-# The only /about page is in english
+# Redirect English-only pages
 
 [[redirects]]
   from = "/en/about/"
   to = "/about/"
+  force = true
+[[redirects]]
+  from = "/en/grantee-finance-form"
+  to = "/applicants/grantee-finance"
   force = true
 
 # Redirect old pages with no lang specified


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add redirect on old page:
https://esp.ethereum.foundation/en/grantee-finance-form

Now lives at:
https://esp.ethereum.foundation/applicants/grantee-finance

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
