### PR TITLE
Fix cookie policy redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -66,10 +66,6 @@
   to = "/about/who-we-support/"
   force = true
 [[redirects]]
-  from = "/*/cookie-policy/"
-  to = "/cookie-policy/"
-  force = true
-[[redirects]]
   from = "/*/faq/"
   to = "/"
   force = true


### PR DESCRIPTION
Removed cookie policy redirect as the page doesn't exist.