### PR TITLE
Grantee finance form UI fixes

### DIFF
--- a/src/components/forms/GranteeFinanceForm.tsx
+++ b/src/components/forms/GranteeFinanceForm.tsx
@@ -747,7 +747,7 @@ export const GranteeFinanceForm: FC = () => {
                 <MotionBox
                   backgroundColor='brand.button.shadow'
                   h='56px'
-                  w='310px'
+                  w='190px'
                   position='absolute'
                   animate={shadowBoxControl}
                   opacity={!isValid ? 0 : 1}
@@ -755,7 +755,7 @@ export const GranteeFinanceForm: FC = () => {
 
                 <MotionButton
                   backgroundColor='brand.accent'
-                  w='310px'
+                  w='190px'
                   py={7}
                   borderRadius={0}
                   type='submit'
@@ -766,7 +766,7 @@ export const GranteeFinanceForm: FC = () => {
                   onMouseLeave={() => setButtonHovered(false)}
                   pointerEvents={isValid ? 'auto' : 'none'}
                 >
-                  <ImportantText color='white'>Submit Application</ImportantText>
+                  <ImportantText color='white'>Submit</ImportantText>
 
                   <Flex pl={5}>
                     <Image

--- a/src/components/forms/GranteeFinanceForm.tsx
+++ b/src/components/forms/GranteeFinanceForm.tsx
@@ -719,7 +719,7 @@ export const GranteeFinanceForm: FC = () => {
                 color='brand.paragraph'
                 fontSize='input'
                 mt={3}
-                {...register('granteeSecurityID', { required: true, maxLength: 255 })}
+                {...register('granteeSecurityID', { required: true, maxLength: 18 })}
               />
 
               {errors?.granteeSecurityID?.type === 'required' && (
@@ -732,7 +732,7 @@ export const GranteeFinanceForm: FC = () => {
               {errors?.granteeSecurityID?.type === 'maxLength' && (
                 <Box mt={1}>
                   <PageText as='small' fontSize='helpText' color='red.500'>
-                    Grantee Security ID cannot exceed 255 characters.
+                    Grantee Security ID cannot exceed 18 characters.
                   </PageText>
                 </Box>
               )}

--- a/src/components/layout/ApplicantsLayout.tsx
+++ b/src/components/layout/ApplicantsLayout.tsx
@@ -10,6 +10,7 @@ import {
   APPLICANTS_TABS,
   APPLICANTS_TABS_MAP,
   APPLICANTS_URL,
+  GRANTEE_FINANCE_URL,
   OFFICE_HOURS_URL,
   PROJECT_GRANTS_URL,
   SMALL_GRANTS_URL
@@ -68,9 +69,11 @@ export const ApplicantsLayout: FC = ({ children }) => {
     }
   };
 
+  const isGranteeFinance = router.pathname === GRANTEE_FINANCE_URL;
+
   return (
     <>
-      <Stack mb={5} px={{ base: 5, md: 12 }} py={3}>
+      <Stack mb={5} px={{ base: 5, md: 12 }} py={3} display={!isGranteeFinance ? 'block' : 'none'}>
         <section id='hero'>
           <Description
             title='For Applicants'
@@ -98,6 +101,7 @@ export const ApplicantsLayout: FC = ({ children }) => {
           onChange={index => handleChange(index)}
           variant='unstyled'
           isLazy
+          display={!isGranteeFinance ? 'block' : 'none'}
         >
           <TabList whiteSpace='nowrap' h='64px' pl={6} role='tablist'>
             {APPLICANTS_TABS.map(tabElement => (
@@ -124,7 +128,7 @@ export const ApplicantsLayout: FC = ({ children }) => {
         </Tabs>
       </Flex>
 
-      <Stack px={{ base: 5, md: 12 }}>
+      <Stack px={{ base: !isGranteeFinance ? 5 : 0, md: 12 }}>
         <Stack mb={8}>{children}</Stack>
       </Stack>
     </>

--- a/src/pages/applicants/grantee-finance/index.tsx
+++ b/src/pages/applicants/grantee-finance/index.tsx
@@ -16,7 +16,14 @@ const GranteeFinancePage: NextPage = () => {
         <meta name='robots' content='noindex' />
       </Head>
 
-      <Box bg='white' position='relative' py={{ md: 12 }} px={{ md: 24, lg: 32, xl: 72 }}>
+      <Box
+        bg='white'
+        position='relative'
+        pt={{ base: 12 }}
+        pb={{ base: 28, md: 32, lg: 16 }}
+        px={{ base: 5, md: 24, lg: 32, xl: 72 }}
+        mb={-8}
+      >
         <Stack>
           <section id='description'>
             <PageSubheading mb={8} textAlign='center'>


### PR DESCRIPTION
This PR adds some UI fixes to Grantee Finance Form

## Description

- removes `applicants` tabs & hero from Grantee Finance Form page
- updates submit button width & text

closes #188 
