### PR TITLE
Generic repo field for Project Grants

### DIFF
--- a/src/components/forms/ProjectGrantsForm.tsx
+++ b/src/components/forms/ProjectGrantsForm.tsx
@@ -364,41 +364,35 @@ export const ProjectGrantsForm: FC = () => {
           )}
         </FormControl>
 
-        <FormControl id='github-control' mb={8}>
-          <FormLabel htmlFor='github' mb={1}>
-            <PageText fontSize='input'>Project Repo</PageText>
+        <FormControl id='project-repo-control' mb={8}>
+          <FormLabel htmlFor='projectRepo' mb={1}>
+            <PageText fontSize='input'>Project repo</PageText>
           </FormLabel>
-          <PageText fontSize='input' position='absolute' bottom='15.5px' left={4} zIndex={9}>
-            https://github.com/
-          </PageText>
 
           <PageText as='small' fontSize='helpText' color='brand.helpText'>
             GitHub or other public repository of the project or related work.
           </PageText>
 
           <Input
-            id='github'
+            id='projectRepo'
             type='text'
-            placeholder='yourgithubaccount'
             bg='white'
             borderRadius={0}
             borderColor='brand.border'
             h='56px'
             _placeholder={{ fontSize: 'input' }}
-            position='relative'
             color='brand.paragraph'
             fontSize='input'
-            pl={36}
             mt={3}
-            {...register('github', {
+            {...register('projectRepo', {
               maxLength: 255
             })}
           />
 
-          {errors?.github?.type === 'maxLength' && (
+          {errors?.projectRepo?.type === 'maxLength' && (
             <Box mt={1}>
               <PageText as='small' fontSize='helpText' color='red.500'>
-                GitHub URL cannot exceed 255 characters.
+                Repo name cannot exceed 255 characters.
               </PageText>
             </Box>
           )}

--- a/src/components/forms/api.ts
+++ b/src/components/forms/api.ts
@@ -3,7 +3,7 @@ import {
   DevconGrantsFormData,
   GranteeFinanceFormData
 } from './../../types';
-import { getGitHub, getWebsite } from '../../utils';
+import { getWebsite } from '../../utils';
 
 import { OfficeHoursFormData, ProjectGrantsFormData, SmallGrantsFormData } from '../../types';
 
@@ -49,7 +49,6 @@ export const api = {
         // Company is a required field in SF, we're using the Name as default value if no company provided
         company: data.company === 'N/A' ? `${data.firstName} ${data.lastName}` : data.company,
         website: getWebsite(data.website),
-        github: getGitHub(data.github),
         projectCategory: data.projectCategory.value,
         country: data.country.value,
         timezone: data.timezone.value,

--- a/src/pages/api/project-grants.ts
+++ b/src/pages/api/project-grants.ts
@@ -44,7 +44,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       Company: fieldsSanitized.company,
       Project_Name__c: fieldsSanitized.projectName,
       Website: fieldsSanitized.website,
-      Github_Link__c: fieldsSanitized.github,
+      Github_Link__c: fieldsSanitized.projectRepo,
       Twitter__c: fieldsSanitized.twitter,
       Team_Profile__c: fieldsSanitized.teamProfile,
       Project_Description__c: fieldsSanitized.projectDescription,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export type ProjectGrantsFormData = {
   company: string; // SF API: Company
   projectName: string; // SF API: Project_Name__c
   website: string; // SF API: Website
-  github: string; // SF API: Github_Link__c
+  projectRepo: string; // SF API: Github_Link__c
   twitter: string; // SF API: Twitter__c
   teamProfile: string; // SF API: Team_Profile__c
   projectDescription: string; // SF API: Project_Description__c

--- a/src/utils/getGitHub.ts
+++ b/src/utils/getGitHub.ts
@@ -1,1 +1,0 @@
-export const getGitHub = (github: string) => (github ? `https://github.com/${github}` : '');

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,5 @@
 export * from './getBg';
 export * from './getBgGradient';
-export * from './getGitHub';
 export * from './getLayoutHeight';
 export * from './getWebsite';
 export * from './selectedLink';


### PR DESCRIPTION
This PR makes the Project Repo field generic instead of just supporting GitHub URL's

## Description

- updates repo field on Project Grants form to make it generic
- removes unused `getGithub` util




