### PR TITLE
refactor: move newsletter signup fetch to /api

### DIFF
--- a/src/components/forms/api.ts
+++ b/src/components/forms/api.ts
@@ -1,16 +1,20 @@
 import {
   AcademicGrantsFormData,
   DevconGrantsFormData,
-  GranteeFinanceFormData
+  GranteeFinanceFormData,
+  NewsletterFormData,
+  OfficeHoursFormData,
+  ProjectGrantsFormData,
+  SmallGrantsFormData
 } from './../../types';
-import { getWebsite } from '../../utils';
 
-import { OfficeHoursFormData, ProjectGrantsFormData, SmallGrantsFormData } from '../../types';
+import { getWebsite } from '../../utils';
 
 import {
   API_ACADEMIC_GRANTS,
   API_DEVCON_GRANTS,
   API_GRANTEE_FINANCE,
+  API_NEWSLETTER_SIGNUP_URL,
   API_OFFICE_HOURS,
   API_PROJECT_GRANTS,
   API_SMALL_GRANTS_EVENT,
@@ -143,6 +147,18 @@ export const api = {
       };
 
       return fetch(API_DEVCON_GRANTS, devconGrantsRequestOptions);
+    }
+  },
+  newsletter: {
+    submit: (data: NewsletterFormData) => {
+      const newsletterRequestOptions: RequestInit = {
+        ...methodOptions,
+        body: JSON.stringify({
+          ...data
+        })
+      };
+
+      return fetch(API_NEWSLETTER_SIGNUP_URL, newsletterRequestOptions);
     }
   }
 };

--- a/src/components/forms/constants.ts
+++ b/src/components/forms/constants.ts
@@ -1488,3 +1488,4 @@ export const API_SMALL_GRANTS_EVENT = '/api/small-grants/event';
 export const API_ACADEMIC_GRANTS = '/api/academic-grants';
 export const API_DEVCON_GRANTS = '/api/devcon-grants';
 export const API_GRANTEE_FINANCE = '/api/grantee-finance';
+export const API_NEWSLETTER_SIGNUP_URL = '/api/newsletter-signup';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -160,7 +160,6 @@ export const DEVCON_URL = 'https://devcon.org/';
 
 // api
 export const DOWNLOAD_APPLICATION_URL = '/projectGrantsApplication.docx';
-export const API_NEWSLETTER_SIGNUP_URL = '/api/newsletter-signup';
 
 // grants list
 export const CURRENT_GRANTS_QUARTERS = ['3', '4'];

--- a/src/pages/api/newsletter-signup.ts
+++ b/src/pages/api/newsletter-signup.ts
@@ -8,6 +8,7 @@ mailchimp.setConfig({
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { body, method } = req;
+  const { email } = body;
 
   if (method !== 'POST') {
     return res.status(405).end(`Method ${method} Not Allowed`);
@@ -15,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     await mailchimp.lists.addListMember(process.env.MAILCHIMP_LIST_ID!, {
-      email_address: body,
+      email_address: email,
       status: 'subscribed',
       merge_fields: {
         NEWSLETTER: 'true'


### PR DESCRIPTION
This PR moves newsletter signup fetch logic to `/api`

## Description

- update fetch logic in `NewsletterSignup` to use `/api` instead
- update constants
