### PR TITLE
chore: redirect /academic-grants to /applicants

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -231,10 +231,10 @@
   to = "/applicants/"
   force = true
 [[redirects]]
-  from = "/academic-grants/"
-  to = "/academic-grants/apply/"
+  from = "/academic-grants/apply/"
+  to = "/applicants/"
   force = true
 [[redirects]]
-  from = "/academic-grants/"
-  to = "/academic-grants/thank-you/"
+  from = "/academic-grants/thank-you/"
+  to = "/applicants/"
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -226,3 +226,15 @@
   from = "/local-grants/colombia/"
   to = "/applicants/"
   force = true
+[[redirects]]
+  from = "/academic-grants/"
+  to = "/applicants/"
+  force = true
+[[redirects]]
+  from = "/academic-grants/"
+  to = "/academic-grants/apply/"
+  force = true
+[[redirects]]
+  from = "/academic-grants/"
+  to = "/academic-grants/thank-you/"
+  force = true

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,24 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
-  target: 'serverless'
+  target: 'serverless',
+  redirects: async () => {
+    return [
+      {
+        source: '/academic-grants',
+        destination: '/applicants',
+        permanent: true
+      },
+      {
+        source: '/academic-grants/apply',
+        destination: '/applicants',
+        permanent: true
+      },
+      {
+        source: '/academic-grants/thank-you',
+        destination: '/applicants',
+        permanent: true
+      }
+    ];
+  }
 };

--- a/src/pages/academic-grants/apply.tsx
+++ b/src/pages/academic-grants/apply.tsx
@@ -4,14 +4,6 @@ import type { NextPage } from 'next';
 import { PageMetadata, PageSubheading, PageText } from '../../components/UI';
 import { ACADEMIC_GRANTS_EMAIL_ADDRESS } from '../../constants';
 
-// Academic Grants Round is currently closed, so we return a 404 page instead
-export function getStaticProps() {
-  return {
-    // returns the default 404 page with a status code of 404
-    notFound: true
-  };
-}
-
 const AcademicGrantsApply: NextPage = () => {
   return (
     <>

--- a/src/pages/academic-grants/index.tsx
+++ b/src/pages/academic-grants/index.tsx
@@ -21,14 +21,6 @@ import {
   WHO_WE_SUPPORT_URL
 } from '../../constants';
 
-// Academic Grants Round is currently closed, so we return a 404 page instead
-export function getStaticProps() {
-  return {
-    // returns the default 404 page with a status code of 404
-    notFound: true
-  };
-}
-
 const AcademicGrants: NextPage = () => {
   // `threshold` option allows us to control the % of visibility required before triggering the Intersection Observer
   // https://react-intersection-observer.vercel.app/?path=/story/introduction--page#options

--- a/src/pages/academic-grants/thank-you.tsx
+++ b/src/pages/academic-grants/thank-you.tsx
@@ -5,14 +5,6 @@ import Head from 'next/head';
 import { PageMetadata, PageSubheading, PageText } from '../../components/UI';
 import { ACADEMIC_GRANTS_EMAIL_ADDRESS } from '../../constants';
 
-// Academic Grants Round is currently closed, so we return a 404 page instead
-export function getStaticProps() {
-  return {
-    // returns the default 404 page with a status code of 404
-    notFound: true
-  };
-}
-
 const AcademicGrantsThankYou: NextPage = () => {
   return (
     <>


### PR DESCRIPTION
This PR adds some redirections for the`/academic-grants` page, as the Academic Grants Round is currently closed.

`/academic-grants --> /applicants`
`/academic-grants/apply --> /applicants`
`/academic-grants/thank-you --> /applicants`


