### PR TITLE
fix: grantee finance form fields should be reseted when changing paym…

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://esp.ethereum.foundation</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.417Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/about</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.417Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/about/how-we-support</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.417Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/about/who-we-support</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.417Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/academic-grants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.417Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/academic-grants/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.417Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/applicants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.417Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/applicants/office-hours</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.417Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/applicants/office-hours/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.417Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/applicants/project-grants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.418Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/applicants/project-grants/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.418Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/applicants/small-grants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.418Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/applicants/small-grants/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.418Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/devcon-grants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.418Z</lastmod></url>
-<url><loc>https://esp.ethereum.foundation/devcon-grants/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-03-11T21:19:46.418Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/about</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/about/how-we-support</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/about/who-we-support</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/academic-grants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/academic-grants/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/applicants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/applicants/office-hours</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/applicants/office-hours/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/applicants/project-grants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/applicants/project-grants/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/applicants/small-grants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/applicants/small-grants/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/devcon-grants</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
+<url><loc>https://esp.ethereum.foundation/devcon-grants/apply</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-15T19:25:49.864Z</lastmod></url>
 </urlset>

--- a/src/components/forms/GranteeFinanceForm.tsx
+++ b/src/components/forms/GranteeFinanceForm.tsx
@@ -38,7 +38,8 @@ export const GranteeFinanceForm: FC = () => {
     register,
     control,
     formState: { errors, isValid, isSubmitting },
-    reset
+    reset,
+    getValues
   } = methods;
 
   const hasPaymentPreferenceSet = paymentPreference !== '';
@@ -110,6 +111,21 @@ export const GranteeFinanceForm: FC = () => {
                   onChange={(value: PaymentPreference) => {
                     onChange(value);
                     setPaymentPreference(value);
+                    reset({
+                      paymentPreference: getValues('paymentPreference'),
+                      beneficiaryName: getValues('beneficiaryName'),
+                      contactEmail: getValues('contactEmail'),
+                      beneficiaryAddress: '',
+                      fiatCurrencyCode: '',
+                      bankName: '',
+                      bankAddress: '',
+                      IBAN: '',
+                      SWIFTCode: '',
+                      tokenPreference: 'ETH',
+                      l2Payment: 'No',
+                      ethAddress: '',
+                      daiAddress: ''
+                    });
                   }}
                   value={value}
                   fontSize='input'
@@ -231,6 +247,15 @@ export const GranteeFinanceForm: FC = () => {
                       onChange={(value: TokenPreference) => {
                         onChange(value);
                         setTokenPreference(value);
+                        reset({
+                          paymentPreference: getValues('paymentPreference'),
+                          beneficiaryName: getValues('beneficiaryName'),
+                          contactEmail: getValues('contactEmail'),
+                          tokenPreference: getValues('tokenPreference'),
+                          l2Payment: getValues('l2Payment'),
+                          ethAddress: '',
+                          daiAddress: ''
+                        });
                       }}
                       value={value}
                       fontSize='input'


### PR DESCRIPTION
This PR fixes the Grantee Finance Form state, which should be reseted when the user updates the payment preferences (ETH/DAI/Fiat), keeping the `beneficiaryName` and `contactEmail`