### PR TITLE
chore: add body request data typings to avoid issues on destructuring

### DIFF
--- a/src/pages/api/academic-grants.ts
+++ b/src/pages/api/academic-grants.ts
@@ -1,13 +1,16 @@
 import jsforce from 'jsforce';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { NextApiResponse } from 'next';
 
 import addRowToSpreadsheet from '../../utils/addRowToSpreadsheet';
+
 import { verifyCaptcha } from '../../middlewares';
+
+import { AcademicGrantsNextApiRequest } from '../../types';
 
 const googleSpreadsheetId = process.env.GOOGLE_ACADEMIC_SPREADSHEET_ID;
 const googleSheetName = process.env.GOOGLE_ACADEMIC_SHEET_NAME;
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: AcademicGrantsNextApiRequest, res: NextApiResponse) {
   const { body } = req;
   const {
     firstName: FirstName,

--- a/src/pages/api/devcon-grants.ts
+++ b/src/pages/api/devcon-grants.ts
@@ -1,13 +1,16 @@
 import jsforce from 'jsforce';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { NextApiResponse } from 'next';
 
 import addRowToSpreadsheet from '../../utils/addRowToSpreadsheet';
+
 import { verifyCaptcha } from '../../middlewares';
+
+import { DevconGrantsNextApiRequest } from '../../types';
 
 const googleSpreadsheetId = process.env.GOOGLE_DEVCON_SPREADSHEET_ID;
 const googleSheetName = process.env.GOOGLE_DEVCON_SHEET_NAME;
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: DevconGrantsNextApiRequest, res: NextApiResponse) {
   const { body } = req;
   const {
     firstName: FirstName,

--- a/src/pages/api/grantee-finance.ts
+++ b/src/pages/api/grantee-finance.ts
@@ -1,9 +1,11 @@
 import jsforce from 'jsforce';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { NextApiResponse } from 'next';
 
 import { verifyCaptcha } from '../../middlewares';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+import { GranteeFinanceNextApiRequest } from '../../types';
+
+async function handler(req: GranteeFinanceNextApiRequest, res: NextApiResponse) {
   const { body } = req;
   const {
     beneficiaryName: Beneficiary_Name__c,
@@ -59,7 +61,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           Bank_Address__c: Bank_Address__c.trim(),
           IBAN_Account_Number__c: IBAN_Account_Number__c.trim(),
           SWIFT_Code_BIC__c: SWIFT_Code_BIC__c.trim(),
-          Layer2_Payment__c
+          Layer2_Payment__c // this is a boolean value, no trim applied
         },
         (err, ret) => {
           if (err || !ret.success) {

--- a/src/pages/api/office-hours.ts
+++ b/src/pages/api/office-hours.ts
@@ -1,9 +1,11 @@
 import jsforce from 'jsforce';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { NextApiResponse } from 'next';
 
 import { verifyCaptcha } from '../../middlewares';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+import { OfficeHoursNextApiRequest } from '../../types';
+
+async function handler(req: OfficeHoursNextApiRequest, res: NextApiResponse) {
   const { body } = req;
   const {
     firstName: FirstName,

--- a/src/pages/api/small-grants/event.ts
+++ b/src/pages/api/small-grants/event.ts
@@ -1,9 +1,11 @@
 import jsforce from 'jsforce';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { NextApiResponse } from 'next';
 
 import { verifyCaptcha } from '../../../middlewares';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+import { SmallGrantsEventNextApiRequest } from '../../../types';
+
+async function handler(req: SmallGrantsEventNextApiRequest, res: NextApiResponse) {
   const { body } = req;
   const {
     // General

--- a/src/pages/api/small-grants/project.ts
+++ b/src/pages/api/small-grants/project.ts
@@ -1,9 +1,11 @@
 import jsforce from 'jsforce';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { NextApiResponse } from 'next';
 
 import { verifyCaptcha } from '../../../middlewares';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+import { SmallGrantsProjectNextApiRequest } from '../../../types';
+
+async function handler(req: SmallGrantsProjectNextApiRequest, res: NextApiResponse) {
   const { body } = req;
   const {
     // General

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { NextApiRequest } from 'next';
 import {
   ACADEMIC_GRANTS_PROJECT_CATEGORY_OPTIONS,
   PROJECT_GRANTS_PROJECT_CATEGORY_OPTIONS,
@@ -272,4 +273,175 @@ export interface Grant {
 export interface SidebarLink {
   text: string;
   href: string;
+}
+
+// body request data types
+export interface OfficeHoursNextApiRequest extends NextApiRequest {
+  body: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    individualOrTeam: string;
+    company: string;
+    officeHoursRequest: string;
+    projectName: string;
+    projectDescription: string;
+    additionalInfo: string;
+    projectCategory: string;
+    otherReasonForMeeting: string;
+    howDidYouHearAboutESP: string;
+    timezone: string;
+  };
+}
+
+export interface GranteeFinanceNextApiRequest extends NextApiRequest {
+  body: {
+    beneficiaryName: string;
+    contactEmail: string;
+    notes: string;
+    ethAddress: string;
+    daiAddress: string;
+    beneficiaryAddress: string;
+    fiatCurrencyCode: string;
+    bankName: string;
+    bankAddress: string;
+    IBAN: string;
+    SWIFTCode: string;
+    granteeSecurityID: string;
+    l2Payment: boolean;
+  };
+}
+
+export interface DevconGrantsNextApiRequest extends NextApiRequest {
+  body: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    company: string;
+    eventPreviousWork: string;
+    teamProfile: string;
+    eventName: string;
+    eventDate: string;
+    sponsorshipLink: string;
+    sponsorshipDetails: string;
+    projectDescription: string;
+    eventType: string;
+    eventFormat: string;
+    city: string;
+    twitter: string;
+    expectedAttendees: string;
+    targetAudience: string;
+    confirmedSpeakers: string;
+    confirmedSponsors: string;
+    proposedTimeline: string;
+    requestedAmount: string;
+    additionalInfo: string;
+    howDidYouHearAboutESP: string;
+  };
+}
+
+export interface AcademicGrantsNextApiRequest extends NextApiRequest {
+  body: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    POCisAuthorisedSignatory: boolean;
+    authorisedSignatoryInformation: string;
+    applyingAs: string;
+    applyingAsOther: string;
+    company: string;
+    country: string;
+    countriesOfTeam: string;
+    timezone: string;
+    projectName: string;
+    projectDescription: string;
+    projectCategory: string;
+    teamProfile: string;
+    projectPreviousWork: string;
+    grantScope: string;
+    projectGoals: string;
+    problemBeingSolved: string;
+    isYourProjectPublicGood: string;
+    requestedAmount: string;
+    proposedTimeline: string;
+    challenges: string;
+    additionalSupportRequests: string;
+    howDidYouHearAboutGrantsWave: string;
+    referralSourceIfOther: string;
+    wouldYouShareYourResearch: string;
+    linkedinProfile: string;
+    twitter: string;
+    telegram: string;
+    repeatApplicant: boolean;
+    canTheEFReachOut: boolean;
+    additionalInfo: string;
+  };
+}
+
+export interface SmallGrantsEventNextApiRequest extends NextApiRequest {
+  body: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    individualOrTeam: string;
+    company: string;
+    city: string;
+    country: string;
+    website: string;
+    twitter: string;
+    projectCategory: string;
+    individualOrTeamSummary: string;
+    howDidYouHearAboutESP: string;
+    referrals: string;
+    additionalInfo: string;
+    eventName: string;
+    eventDate: string;
+    eventPreviousWork: string;
+    sponsorshipLink: string;
+    sponsorshipDetails: string;
+    sponsorshipTopics: string;
+    eventType: string;
+    eventFormat: string;
+    expectedAttendees: string;
+    targetAudience: string;
+    confirmedSpeakers: string;
+    confirmedSponsors: string;
+    eventBudgetBreakdown: string;
+    eventRequestedAmount: string;
+  };
+}
+
+export interface SmallGrantsProjectNextApiRequest extends NextApiRequest {
+  body: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    individualOrTeam: string;
+    company: string;
+    city: string;
+    country: string;
+    website: string;
+    twitter: string;
+    projectCategory: string;
+    individualOrTeamSummary: string;
+    howDidYouHearAboutESP: string;
+    referrals: string;
+    additionalInfo: string;
+    projectName: string;
+    projectRepo: string;
+    projectPreviousWork: string;
+    projectDescription: string;
+    problemBeingSolved: string;
+    whyIsProjectImportant: string;
+    howDoesYourProjectDiffer: string;
+    projectRequestedAmount: string;
+    proposedTimeline: string;
+    isYourProjectPublicGood: string;
+    isOpenSource: string;
+    sustainabilityPlan: string;
+    otherProjects: string;
+    repeatApplicant: boolean;
+    progress: string;
+    otherFunding: string;
+  };
 }


### PR DESCRIPTION
This PR adds body requests data typing to avoid issues on destructuring for API routes. By default, the `NextApiRequest` type sets body data types as `any`.
