### PR TITLE
Consistent spelling of EthStaker

### DIFF
--- a/src/pages/merge-data-challenge/index.tsx
+++ b/src/pages/merge-data-challenge/index.tsx
@@ -575,7 +575,7 @@ const MergeDataChallenge: NextPage = () => {
                           isExternal
                           _hover={{ textDecoration: 'none' }}
                         >
-                          ethstaker
+                          EthStaker
                         </Link>
                         {' '} - <PageText as='span' fontStyle="italic">Discord</PageText>
                         <List>
@@ -587,7 +587,7 @@ const MergeDataChallenge: NextPage = () => {
                               isExternal
                               _hover={{ textDecoration: 'none' }}
                             >
-                              ETHStaker Merge Data Challenge
+                              EthStaker Merge Data Challenge
                             </Link>
                             {' '} - <PageText as='span' fontStyle="italic">Discord Channel</PageText>
                           </ListItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Change `ethstaker` and `ETHStaker` to a consistent spelling of `EthStaker`
