### PR TITLE
Fix twitter title

### DIFF
--- a/src/components/UI/PageMetadata.tsx
+++ b/src/components/UI/PageMetadata.tsx
@@ -38,7 +38,7 @@ export const PageMetadata: FC<Props> = ({
       <meta property='twitter:url' content='https://esp.ethereum.foundation/' />
       <meta name='twitter:creator' content='@EF_ESP' />
       <meta name='twitter:site' content='@EF_ESP' />
-      <meta name='twitter:title' content='EF Ecosystem Support Program' />
+      <meta name='twitter:title' content={fullTitle} />
       <meta name='twitter:description' content={description} />
       <meta name='twitter:image' content={image} />
     </Head>

--- a/src/components/UI/PageMetadata.tsx
+++ b/src/components/UI/PageMetadata.tsx
@@ -14,17 +14,16 @@ export const PageMetadata: FC<Props> = ({
   description,
   image = HOMEPAGE_HERO_MOBILE_URL
 }) => {
+  const fullTitle = `${title} | ${HEAD_TITLE}`;
   return (
     <Head>
-      <title>
-        {title} | {HEAD_TITLE}
-      </title>
-      <meta name='title' content={`${title} | ${HEAD_TITLE}`} />
+      <title>{fullTitle}</title>
+      <meta name='title' content={fullTitle} />
       <meta name='description' content={description} />
       <meta name='application-name' content='Ethereum Foundation ESP' />
       <meta name='image' content={image} />
       {/* OpenGraph */}
-      <meta property='og:title' content={`${title} | ${HEAD_TITLE}`} />
+      <meta property='og:title' content={fullTitle} />
       <meta property='og:description' content={description} />
       <meta property='og:type' content='website' />
       <meta property='og:site_name' content='Ethereum Foundation ESP'></meta>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update Twitter title tag to use the page title vs. default site title.

## Related Issue

None, just noticed e.g. on TG that it's pulling in the wrong title tag:
![Image 2022-09-28 at 12 20 56 PM](https://user-images.githubusercontent.com/8097623/192870272-9ce234c2-50ae-4793-83f4-aa651025f5dc.jpg)
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
