### PR TITLE
fix bug which appends https:// to urls that have http or https already

### DIFF
--- a/src/utils/getWebsite.ts
+++ b/src/utils/getWebsite.ts
@@ -1,1 +1,7 @@
-export const getWebsite = (website: string) => (website ? `https://${website}` : '');
+export const getWebsite = (website: string) => (
+  website 
+    ? website.includes('https://') || website.includes('http://')
+      ? website
+      : `https://${website}` 
+    : ''
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixes the bug which appends `https://` to valid url strings

## Related Issue
https://github.com/ethereum/esp-website/issues/242
