### PR TITLE
Add redirects from closed applications to `/applicants` page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -238,3 +238,19 @@
   from = "/academic-grants/thank-you/"
   to = "/applicants/"
   force = true
+[[redirects]]
+  from = "/merge-data-challenge/"
+  to = "/applicants/"
+  force = true
+[[redirects]]
+  from = "/merge-data-challenge/apply/"
+  to = "/applicants/"
+  force = true
+[[redirects]]
+  from = "/semaphore-grants/"
+  to = "/applicants/"
+  force = true
+[[redirects]]
+  from = "/semaphore-grants/apply/"
+  to = "/applicants/"
+  force = true


### PR DESCRIPTION
## Description

Temporary solution until we tackle https://www.notion.so/efdn/ESP-Closed-round-banner-20ae7490c963459f89cd1e26cf745062