### PR TITLE
Update copy on the `BannerApplicationClosed`

### DIFF
--- a/src/components/UI/common/BannerApplicationClosed.tsx
+++ b/src/components/UI/common/BannerApplicationClosed.tsx
@@ -15,6 +15,7 @@ export const BannerApplicationClosed: FC<Props> = props => {
       py={6}
       borderRadius='xl'
       flexDirection='column'
+      textAlign='center'
       {...props}
     >
       <Heading fontSize='h4' fontWeight={700} mb={2}>

--- a/src/components/UI/common/BannerApplicationClosed.tsx
+++ b/src/components/UI/common/BannerApplicationClosed.tsx
@@ -1,7 +1,9 @@
 import { FC } from 'react';
-import { ChakraProps, Heading } from '@chakra-ui/react';
+import { ChakraProps, Heading, Text, Link } from '@chakra-ui/react';
 
 import { Banner } from './Banner';
+
+import { APPLICANTS_URL } from '../../../constants';
 
 interface Props extends ChakraProps {}
 
@@ -12,11 +14,26 @@ export const BannerApplicationClosed: FC<Props> = props => {
       color='brand.heading'
       py={6}
       borderRadius='xl'
+      flexDirection='column'
       {...props}
     >
-      <Heading fontSize='h4' fontWeight={700}>
-        Applications are now closed
+      <Heading fontSize='h4' fontWeight={700} mb={2}>
+        Applications for this grant wave are closed.
       </Heading>
+
+      <Text fontSize='paragraph' fontWeight={300}>
+        If you&apos;re still interested in pursuing grants for a project, you can still go through
+        our{' '}
+        <Link
+          fontWeight={700}
+          href={APPLICANTS_URL}
+          color='brand.heading'
+          textDecoration='underline'
+        >
+          standard applications
+        </Link>
+        .
+      </Text>
     </Banner>
   );
 };


### PR DESCRIPTION
Adds copy to redirect users to `/applicants` page.

You can see the new copy here: https://deploy-preview-257--ecosystem-support.netlify.app/layer-2-grants