### PR TITLE
Add proposal field on the Account Abstraction form

### DIFF
--- a/src/components/forms/AccountAbstractionGrantsForm.tsx
+++ b/src/components/forms/AccountAbstractionGrantsForm.tsx
@@ -6,6 +6,7 @@ import {
   FormControl,
   FormLabel,
   Input,
+  Link,
   Radio,
   RadioGroup,
   Stack,
@@ -577,6 +578,68 @@ export const AccountAbstractionGrantsForm: FC = () => {
               <Box mt={1}>
                 <PageText as='small' fontSize='helpText' color='red.500'>
                   Project description cannot exceed 255 characters.
+                </PageText>
+              </Box>
+            )}
+          </FormControl>
+
+          <FormControl id='website-control' isRequired mb={8}>
+            <FormLabel htmlFor='website' mb={1}>
+              <PageText display='inline' fontSize='input'>
+                Grant Proposal URL
+              </PageText>
+            </FormLabel>
+
+            <PageText as='small' fontSize='helpText' color='brand.helpText'>
+              Please provide a link to your grant proposal for review.{' '}
+              <Link
+                fontWeight={700}
+                color='brand.orange.200'
+                href={`https://hackmd.io/@rodrigolvc/Example_Grant`}
+                isExternal
+                _hover={{ textDecoration: 'none' }}
+              >
+                Proposal Template
+              </Link>
+            </PageText>
+
+            <Box position='relative'>
+              <PageText fontSize='input' position='absolute' top='28.5px' left={4} zIndex={9}>
+                https://
+              </PageText>
+              <Input
+                id='website'
+                type='text'
+                placeholder='yourgrantproposal.com'
+                bg='white'
+                borderRadius={0}
+                borderColor='brand.border'
+                h='56px'
+                _placeholder={{ fontSize: 'input' }}
+                position='relative'
+                color='brand.paragraph'
+                fontSize='input'
+                pl={16}
+                mt={3}
+                {...register('website', {
+                  required: true,
+                  maxLength: 255
+                })}
+              />
+            </Box>
+
+            {errors?.website?.type === 'maxLength' && (
+              <Box mt={1}>
+                <PageText as='small' fontSize='helpText' color='red.500'>
+                  The URL cannot exceed 255 characters.
+                </PageText>
+              </Box>
+            )}
+
+            {errors?.website?.type === 'required' && (
+              <Box mt={1}>
+                <PageText as='small' fontSize='helpText' color='red.500'>
+                  A URL is required.
                 </PageText>
               </Box>
             )}

--- a/src/pages/api/account-abstraction-grants.ts
+++ b/src/pages/api/account-abstraction-grants.ts
@@ -36,7 +36,8 @@ async function handler(
       telegram: Alternative_Contact__c,
       repeatApplicant: Repeat_Applicant__c,
       canTheEFReachOut: Can_the_EF_reach_out__c,
-      additionalInfo: Additional_Information__c
+      additionalInfo: Additional_Information__c,
+      website: Website
     } = body;
     const { SF_PROD_LOGIN_URL, SF_PROD_USERNAME, SF_PROD_PASSWORD, SF_PROD_SECURITY_TOKEN } =
       process.env;
@@ -65,6 +66,7 @@ async function handler(
         Time_Zone__c: Time_Zone__c.trim(),
         Project_Name__c: Project_Name__c.trim(),
         Project_Description__c: Project_Description__c.trim(),
+        Website: Website.trim(),
         Category__c: Category__c.trim(),
         Requested_Amount__c: Requested_Amount__c.trim(),
         Referral_Source__c: Referral_Source__c.trim(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,7 @@ export interface AccountAbstractionGrantsFormData extends CaptchaForm {
   timezone: Timezone; // SF API: Time_Zone__c
   projectName: string; // SF API: Project_Name__c
   projectDescription: string; // SF API: Project_Description__c
+  website: string; // SF API: Website
   projectCategory: AcademicGrantsProjectCategory; // SF API: Category__c
   requestedAmount: string; // SF API: Requested_Amount__c
   wouldYouShareYourResearch: WouldYouShareYourResearch; // SF API: Would_you_share_your_research__c
@@ -504,6 +505,7 @@ export interface AccountAbstractionGrantsNextApiRequest extends NextApiRequest {
     timezone: string;
     projectName: string;
     projectDescription: string;
+    website: string;
     projectCategory: string;
     requestedAmount: string;
     wouldYouShareYourResearch: string;


### PR DESCRIPTION
## Description

Added a missing field in the Account Abstraction form. The missing field is `website`. It is the same field & copy we are using in the AGR (https://esp.ethereum.foundation/academic-grants/apply).

![image](https://user-images.githubusercontent.com/468158/222739315-34e2bfdc-9bdb-46ee-a9bf-570693147fde.png)
