### PR TITLE
Remove temporary Matomo tracker

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -23,9 +23,6 @@ import favicon from '../../public/images/favicon.ico';
 import favicon16 from '../../public/images/favicon-16x16.png';
 import favicon32 from '../../public/images/favicon-32x32.png';
 
-const MATOMO_SECONDARY_URL = 'https://ethereumfoundation.matomo.cloud/matomo.php';
-const MATOMO_SECONDARY_SITE_ID = 4;
-
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
@@ -34,7 +31,6 @@ function MyApp({ Component, pageProps }: AppProps) {
       url: process.env.NEXT_PUBLIC_MATOMO_URL!,
       siteId: process.env.NEXT_PUBLIC_MATOMO_SITE_ID!
     });
-    push(['addTracker', MATOMO_SECONDARY_URL, MATOMO_SECONDARY_SITE_ID]);
   }, []);
 
   return (


### PR DESCRIPTION
## Description
Matomo Cloud migration is complete.
- Removes the temporary secondary tracker
- Updated the env vars in Netlify for new Matomo endpoints (`NEXT_PUBLIC_MATOMO_URL` and `NEXT_PUBLIC_MATOMO_SITE_ID`)

