### PR TITLE
fix(UI): the redirect page of samll-grant/thank-you

### DIFF
--- a/src/components/UI/common/ThankYouBody.tsx
+++ b/src/components/UI/common/ThankYouBody.tsx
@@ -18,7 +18,7 @@ export const ThankYouBody: FC<Props> = ({ grantType }) => {
           <Link
             fontWeight={700}
             color='brand.orange.100'
-            href='applicants/small-grants'
+            href='/applicants/small-grants'
             isExternal
             _hover={{ textDecoration: 'none' }}
           >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The page currently redirects to https://esp.ethereum.foundation/applicants/small-grants/applicants/small-grants

## Related Issue

#310
