### PR TITLE
Update SmallGrantsForm styling for clarity

### DIFF
--- a/src/components/forms/SmallGrantsForm.tsx
+++ b/src/components/forms/SmallGrantsForm.tsx
@@ -520,8 +520,8 @@ export const SmallGrantsForm: FC = () => {
 
                 <Box mb={2}>
                   <PageText as='small' fontSize='helpText' color='brand.helpText'>
-                    Please choose a category that your project best fits in. Additional questions
-                    will appear based on your selection.
+                    Please choose a category that your project best fits in. <strong>Additional questions
+                    will appear based on your selection</strong>.
                   </PageText>
                 </Box>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds bold to a sentence in small grants form to make it more obvious to users

## Related Issue

From Discord: ["@pablop would it be possible to get this text bolded on the Small Grants and Project Grants application forms? “Additional questions will appear based on your selection.” Apparently, people don’t see it."](https://discord.com/channels/420394352083337236/998689173542273167/1181648073391357993)
