### PR TITLE
Rename category used in agr form

### DIFF
--- a/src/components/forms/constants.ts
+++ b/src/components/forms/constants.ts
@@ -30,7 +30,7 @@ export const PROJECT_GRANTS_PROJECT_CATEGORY_OPTIONS = [
 
 export const ACADEMIC_GRANTS_PROJECT_CATEGORY_OPTIONS = [
   { value: 'Consensus layer', label: 'Consensus layer' },
-  { value: 'Protocol growth & support', label: 'Protocol growth & support' },
+  { value: 'Protocol growth and support', label: 'Protocol growth and support' },
   {
     value: 'Cryptography and zero knowledge proofs',
     label: 'Cryptography and zero knowledge proofs'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The char `&` was getting encoded on submission and SF was throwing an error. As a workaround, we decided to change it to `and`.
