### PR TITLE
Grantee finance fix

### DIFF
--- a/src/components/forms/GranteeFinanceForm.tsx
+++ b/src/components/forms/GranteeFinanceForm.tsx
@@ -62,8 +62,6 @@ export const GranteeFinanceForm: FC = () => {
   const bankAddress = watch('bankAddress');
   const fiatCurrencyCode = watch('fiatCurrencyCode');
   const isL2Selected = watch('l2Payment')?.includes('Yes');
-  const selectedL2Network = watch('l2Network');
-  const isL2Other = selectedL2Network === 'Other';
 
   // if the bank address contains the string 'India' or the fiat currency code
   // is 'INR', alert for IFSC code within Notes field
@@ -385,54 +383,42 @@ export const GranteeFinanceForm: FC = () => {
                     )}
                   />
 
-                  <Box display={isL2Other ? 'block' : 'none'}>
-                    <Fade in={isL2Other} delay={0.25}>
-                      <FormControl id='l2NetworkOther' isRequired={isL2Other} mb={8}>
-                        <FormLabel htmlFor='l2NetworkOther' mb={1}>
-                          <PageText display='inline' fontSize='input'>
-                            If the Layer 2 network you would like is not available, please let us
-                            know which networks you would like supported, separated by commas
-                          </PageText>
-                        </FormLabel>
+                  <FormControl id='l2NetworkOther' mb={8}>
+                    <FormLabel htmlFor='l2NetworkOther' mb={1}>
+                      <PageText display='inline' fontSize='input'>
+                        If the Layer 2 network you would like is not available, please let us know
+                        which networks you would like supported, separated by commas
+                      </PageText>
+                    </FormLabel>
 
-                        <PageText as='small' fontSize='helpText' color='brand.helpText'>
-                          This question is optional and meant to help the disbursement team gather
-                          data on which Layer 2 networks are most requested.
+                    <PageText as='small' fontSize='helpText' color='brand.helpText'>
+                      This question is optional and meant to help the disbursement team gather data
+                      on which Layer 2 networks are most requested.
+                    </PageText>
+
+                    <Textarea
+                      id='l2NetworkOther'
+                      bg='white'
+                      borderRadius={0}
+                      borderColor='brand.border'
+                      color='brand.paragraph'
+                      fontSize='input'
+                      h='72px'
+                      mt={3}
+                      resize='none'
+                      {...register('l2NetworkOther', {
+                        maxLength: 255
+                      })}
+                    />
+
+                    {errors?.l2NetworkOther?.type === 'maxLength' && (
+                      <Box mt={1}>
+                        <PageText as='small' fontSize='helpText' color='red.500'>
+                          Field cannot exceed 255 characters.
                         </PageText>
-
-                        <Textarea
-                          id='l2NetworkOther'
-                          bg='white'
-                          borderRadius={0}
-                          borderColor='brand.border'
-                          color='brand.paragraph'
-                          fontSize='input'
-                          h='72px'
-                          mt={3}
-                          resize='none'
-                          {...register('l2NetworkOther', {
-                            required: isL2Other,
-                            maxLength: 255
-                          })}
-                        />
-
-                        {errors?.l2NetworkOther?.type === 'required' && (
-                          <Box mt={1}>
-                            <PageText as='small' fontSize='helpText' color='red.500'>
-                              Field is required.
-                            </PageText>
-                          </Box>
-                        )}
-                        {errors?.l2NetworkOther?.type === 'maxLength' && (
-                          <Box mt={1}>
-                            <PageText as='small' fontSize='helpText' color='red.500'>
-                              Field cannot exceed 255 characters.
-                            </PageText>
-                          </Box>
-                        )}
-                      </FormControl>
-                    </Fade>
-                  </Box>
+                      </Box>
+                    )}
+                  </FormControl>
                 </Fade>
               </Box>
             </Fade>

--- a/src/components/forms/api.ts
+++ b/src/components/forms/api.ts
@@ -106,9 +106,7 @@ export const api = {
         method: 'PUT',
         body: JSON.stringify({
           ...data,
-          l2Payment: data.l2Payment === 'Yes',
-          // if l2Network is 'Other', send an empty string to SF because 'Other' doesn't exist in SF
-          l2Network: data.l2Network !== 'Other' ? data.l2Network : ''
+          l2Payment: data.l2Payment === 'Yes'
         })
       };
 

--- a/src/components/forms/constants.ts
+++ b/src/components/forms/constants.ts
@@ -119,8 +119,7 @@ export const WOULD_YOU_SHARE_YOUR_RESEARCH_OPTIONS = [
 // grantee finance
 export const SUPPORTED_LAYERS_2_OPTIONS = [
   { value: 'Arbitrum', label: 'Arbitrum' },
-  { value: 'Optimism', label: 'Optimism' },
-  { value: 'Other', label: 'Other' }
+  { value: 'Optimism', label: 'Optimism' }
 ];
 
 // countries


### PR DESCRIPTION
## Description

Removes the Other option from `l2Network` field and make it required.

Preview: https://deploy-preview-368--ecosystem-support.netlify.app/applicants/grantee-finance

## Related Issue

#360