### PR TITLE
Ignore cursor rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cursor
+.cursorrules
+.cursor


### PR DESCRIPTION
Ignore all files under the .cursor directory as users will use this directory for personal IDE config