### PR TITLE
Implement new other teams section design on homepage

### DIFF
--- a/src/components/UI/HomepageHero.tsx
+++ b/src/components/UI/HomepageHero.tsx
@@ -33,8 +33,17 @@ export const HomepageHero: FC = () => {
           We provide support to the builders of the Ethereum ecosystem.
         </PageSubheading>
 
-        <Flex justifyContent={{ base: 'center', md: 'flex-start' }}>
+        <Flex
+          justifyContent={{ base: 'center', md: 'flex-start' }}
+          gap={4}
+          flexWrap={{ base: 'wrap', md: 'nowrap' }}
+        >
           <ButtonLink label='Learn more' link={APPLICANTS_URL} width='177px' />
+          <ButtonLink
+            label='Other support'
+            link='#other-support'
+            width='fit-content'
+          />
         </Flex>
       </Stack>
       <Box>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,18 @@
-import { Box, Flex, Grid, GridItem, Link, ListItem, Stack, UnorderedList } from '@chakra-ui/react';
+import {
+  Box,
+  Flex,
+  Grid,
+  GridItem,
+  ListItem,
+  SimpleGrid,
+  Stack,
+  UnorderedList
+} from '@chakra-ui/react';
 import type { NextPage } from 'next';
 import Image from 'next/image';
 
 import { HomeAboutCard, PageMetadata, PageSection, PageText } from '../components/UI';
+import { ButtonLink } from '../components/ButtonLink';
 
 import applicantsHero from '../../public/images/applicants-hero.png';
 import smallSucculentSVG from '../../public/images/small-succulent.svg';
@@ -10,10 +20,49 @@ import mediumSucculentSVG from '../../public/images/medium-succulent.svg';
 import bigSucculentSVG from '../../public/images/big-succulent.svg';
 import whatWeSupportTree from '../../public/images/what-we-support-tree.png';
 import howWeSupportRoots from '../../public/images/how-we-support-roots.png';
+import communityOrganizersVector from '../../public/images/community-organizers-vector.svg';
+import otherGrantProgramsVector from '../../public/images/other-grant-programs-vector.svg';
+import researchersVector from '../../public/images/researchers-vector.svg';
 
 import { ABOUT_URL, APPLICANTS_URL, FOUNDER_SUCCESS_URL, ENTERPRISE_ACCELERATION_URL, ETHEREUM_EVERYWHERE_URL } from '../constants';
 
 const Home: NextPage = () => {
+  const otherSupportCards = [
+    {
+      title: 'Founders',
+      description:
+        "Level up your founder journey with access to programs, mentorship, and visibility across the Ethereum ecosystem.",
+      ctaLabel: 'Founder Success',
+      href: FOUNDER_SUCCESS_URL,
+      icon: {
+        src: researchersVector,
+        alt: 'Illustration representing founder success support'
+      }
+    },
+    {
+      title: 'Businesses',
+      description:
+        'Explore potential pathways and opportunities for businesses and enterprise looking to leverage Ethereum.',
+      ctaLabel: 'Enterprise Team',
+      href: ENTERPRISE_ACCELERATION_URL,
+      icon: {
+        src: otherGrantProgramsVector,
+        alt: 'Building illustration representing business growth'
+      }
+    },
+    {
+      title: 'Community Builders',
+      description:
+        'Request support for organizing an event or launching a community initiative.',
+      ctaLabel: 'Ethereum Everywhere',
+      href: ETHEREUM_EVERYWHERE_URL,
+      icon: {
+        src: communityOrganizersVector,
+        alt: 'Community illustration representing collaboration'
+      }
+    }
+  ];
+
   return (
     <>
       <PageMetadata
@@ -207,26 +256,6 @@ const Home: NextPage = () => {
             </Box>
           </section>
 
-          <section id='support'>
-            <Stack
-              bg='brand.warning'
-              borderRadius='10px'
-              p={6}
-              spacing={6}
-            >
-              <PageText>
-                Are you a founder seeking access to programs, mentorship, and visibility across the Ethereum ecosystem? Connect with the <Link href={FOUNDER_SUCCESS_URL} fontWeight={700} color='brand.orange.100' isExternal _hover={{ textDecoration: 'none' }}>Founder Success team</Link> to level up your journey. 
-              </PageText>
-              <PageText>
-                Are you leading a business or enterprise looking to leverage Ethereum? Get in touch with the <Link href={ENTERPRISE_ACCELERATION_URL} fontWeight={700} color='brand.orange.100' isExternal _hover={{ textDecoration: 'none' }}>Enterprise Acceleration team</Link> to explore potential pathways and opportunities. 
-              </PageText>
-              <PageText>
-                Are you organizing an event or launching a community initiative? Reach out to the <Link href={ETHEREUM_EVERYWHERE_URL} fontWeight={700} color='brand.orange.100' isExternal _hover={{ textDecoration: 'none' }}>Ethereum Everywhere team</Link> for support.
-              </PageText>
-            </Stack>
-          </section>
-          
-          
           <section id='our-role'>
             <HomeAboutCard
               bgGradient='linear(to-br, brand.whoWeSupport.bgGradient.start 0%, brand.whoWeSupport.bgGradient.end 100%)'
@@ -294,6 +323,55 @@ const Home: NextPage = () => {
                 Financial support is offered through our Wishlist and RFPs, which highlight funding opportunities curated by EF teams. Non-financial support is available through Office Hours, where builders can receive project feedback, guidance on navigating the ecosystem, or advice on aligning their project with a Wishlist or RFP item.
               </PageText>
             </HomeAboutCard>
+          </section>
+
+          <section id='other-support'>
+            <Stack spacing={6}>
+              <PageSection textAlign='left'>Other EcoDev Teams</PageSection>
+
+              <PageText>
+                Looking for different support? Connect with the team that best matches your next step in the ecosystem.
+              </PageText>
+
+              <SimpleGrid columns={{ base: 1, lg: 2, xl: 3 }} spacing={{ base: 6, md: 8 }}>
+                {otherSupportCards.map((card) => (
+                  <Stack
+                    key={card.title}
+                    bg='brand.warning'
+                    borderRadius='16px'
+                    p={{ base: 6, md: 8 }}
+                    spacing={5}
+                    align='flex-start'
+                    height='100%'
+                  >
+                    <Flex
+                      alignItems='center'
+                      justifyContent='center'
+                      flexWrap={'wrap'}
+                      bg='white'
+                      borderRadius='12px'
+                      p={4}
+                      height='80px'
+                      width='80px'
+                    >
+                      <Image src={card.icon.src} alt={card.icon.alt} width={48} height={48} />
+                    </Flex>
+
+                    <PageSection as='h4' fontSize='20px' lineHeight='28px' textAlign='left'>
+                      {card.title}
+                    </PageSection>
+
+                    <PageText flex={1}>{card.description}</PageText>
+
+                    <ButtonLink
+                      label={card.ctaLabel}
+                      link={card.href}
+                      width='fit-content'
+                    />
+                  </Stack>
+                ))}
+              </SimpleGrid>
+            </Stack>
           </section>
         </Stack>
       </Box>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- **Problem:** The current section is text-heavy and awkwardly placed in the middle of the homepage.
        - Move the section to the bottom of the homepage.
        - Add a navigation button/link at the top of the page (e.g., text: "Other support") that jumps the user down to this section
        - Redesign the section using a more visual "card" layout based on Vanessa's Canva mockup

Preview: https://deploy-preview-462--ecosystem-support.netlify.app/

## Screenshots

<img width="1385" height="507" alt="Screenshot 2025-10-16 at 14 55 50" src="https://github.com/user-attachments/assets/aa1fe586-60b4-42a7-84d6-37498f8797b0" />
<img width="707" height="413" alt="Screenshot 2025-10-16 at 14 55 55" src="https://github.com/user-attachments/assets/afad7664-ad95-4279-99e6-513d87dc6a93" />

## For discussion

- Spacing design system was unclear to me. Designers may want to look before we merge

