### PR TITLE
Extend PhD Fellowship deadline to April 22nd

### DIFF
--- a/content/rounds/phdfp26.mdx
+++ b/content/rounds/phdfp26.mdx
@@ -1,13 +1,13 @@
 ---
 slug: 'phdfp26'
 name: 'PhD Fellowship Program'
-description: 'The Ethereum Foundation is launching a fellowship-style grant program to support Ethereum-related academic work led by current PhD students. Selected Fellows will receive $24,000 USD over one year, intended as a supplement to their existing stipend, with 9-10 Fellowships awarded in total. Proposals are due 23:59 AoE April 1st, 2026.'
+description: 'The Ethereum Foundation is launching a fellowship-style grant program to support Ethereum-related academic work led by current PhD students. Selected Fellows will receive $24,000 USD over one year, intended as a supplement to their existing stipend, with 9-10 Fellowships awarded in total. Proposals are due 23:59 AoE April 22nd, 2026.'
 tags:
   - PhDFP
 heroImage: '/images/phd-fellowship-26-hero.jpeg'
 colorBrand: 'phdFellowship2026Hero'
 startDate: '2026-02-02'
-endDate: '2026-04-01'
+endDate: '2026-04-22'
 ---
 
 ## About
@@ -26,7 +26,7 @@ The Ethereum Foundation is sponsoring the 2026 PhD Fellowship Program to support
 
 The program will award **9-10 Fellowships**, each with a **$24,000 USD** stipend over one year.
 
-Proposals are due **23:59 AoE April 1st, 2026**.
+Proposals are due **23:59 AoE April 22nd, 2026**.
 
 ## Requirements
 
@@ -44,7 +44,7 @@ Proposals are due **23:59 AoE April 1st, 2026**.
 
 ## Deadline
 
-The application window opens on **Monday, February 2nd, 2026** and closes on **Wednesday, April 1st, 2026**.
+The application window opens on **Monday, February 2nd, 2026** and closes on **Wednesday, April 22nd, 2026**.
 
 ## Selection criteria
 


### PR DESCRIPTION
## Summary

- Extends the PhD Fellowship Program (phdfp26) submission deadline from April 1st to April 22nd, 2026 (23:59 AoE / UTC-12)
- Requested by the Academic Secretariat team

## Test plan

- [x] Verify the round page shows the updated deadline
- [x] Confirm the form remains accessible until the new end date