### PR TITLE
Extend PhD Fellowship window to 01:00 UTC April 24th (ISO datetime support)

### DIFF
--- a/content/rounds/phdfp26.mdx
+++ b/content/rounds/phdfp26.mdx
@@ -8,7 +8,7 @@ heroImage: '/images/phd-fellowship-26-hero.jpeg'
 colorBrand: 'phdFellowship2026Hero'
 startDate: '2026-02-02'
 endDate: '2026-04-22'
-effectiveEndDate: '2026-04-23'
+effectiveEndDate: '2026-04-24T01:00:00Z'
 ---
 
 ## About

--- a/content/rounds/phdfp26.mdx
+++ b/content/rounds/phdfp26.mdx
@@ -8,6 +8,7 @@ heroImage: '/images/phd-fellowship-26-hero.jpeg'
 colorBrand: 'phdFellowship2026Hero'
 startDate: '2026-02-02'
 endDate: '2026-04-22'
+effectiveEndDate: '2026-04-23'
 ---
 
 ## About

--- a/docs/solutions/architecture/grant-round-date-fields-20260203.md
+++ b/docs/solutions/architecture/grant-round-date-fields-20260203.md
@@ -68,6 +68,13 @@ These control:
 - Visibility on Open Rounds page
 - "Applications Closed" banner display
 
+### Accepted Value Formats
+
+Any of the four date fields accepts either:
+
+- **Date only**, `YYYY-MM-DD` (e.g. `'2026-04-22'`) — interpreted as AoE, 00:00:00 for start dates and 23:59:59 for end dates. This is the default for public-facing deadlines.
+- **ISO datetime**, any string containing `T` (e.g. `'2026-04-24T01:00:00Z'`, `'2026-04-24T01:00:00-05:00'`) — parsed as a literal UTC instant. AoE is ignored. Use this when a round must open or close at a specific wall-clock time that does not fall on an AoE day boundary.
+
 ## How It Works
 
 ```typescript
@@ -79,12 +86,14 @@ export function computeRoundStatus(
   effectiveEndDate?: string     // Optional override
 ): RoundStatus {
   const now = Date.now();
-  // Use effective dates if provided, otherwise fall back to display dates
-  const startAoE = toAoETimestamp(effectiveStartDate || startDate, true);
-  const endAoE = toAoETimestamp(effectiveEndDate || endDate, false);
+  // Use effective dates if provided, otherwise fall back to display dates.
+  // resolveRoundTimestamp accepts either AoE date-only values or literal
+  // ISO datetimes — see "Accepted Value Formats" above.
+  const start = resolveRoundTimestamp(effectiveStartDate || startDate, true);
+  const end = resolveRoundTimestamp(effectiveEndDate || endDate, false);
 
-  if (now < startAoE) return 'upcoming';
-  if (now > endAoE) return 'closed';
+  if (now < start) return 'upcoming';
+  if (now > end) return 'closed';
   return 'active';
 }
 ```
@@ -114,7 +123,19 @@ effectiveEndDate: '2026-04-02'  # Actually closes April 2nd
 
 **Result:** Users see "April 1st" deadline, but applications accepted until Apr 2nd 23:59:59 AoE.
 
-### 3. Delayed Opening
+### 3. Short Grace Period (Precise UTC Close Time)
+
+When a short grace period is needed and an extra AoE day would over-extend by many hours, use the ISO datetime form on `effectiveEndDate`:
+
+```yaml
+startDate: '2026-02-02'
+endDate: '2026-04-22'                        # Users still see April 22nd
+effectiveEndDate: '2026-04-24T01:00:00Z'     # Actually closes 01:00 UTC April 24th
+```
+
+**Result:** Public deadline stays April 22nd, form quietly stays open until the exact instant. Used for the 2026 PhD Fellowship grace period (PR #524).
+
+### 4. Delayed Opening
 
 Announce a round early but don't accept applications until later:
 
@@ -126,7 +147,7 @@ endDate: '2026-04-01'
 
 **Result:** Round page is accessible, but not shown in "Open Rounds" until Feb 5th.
 
-### 4. Both Overrides
+### 5. Both Overrides
 
 ```yaml
 startDate: '2026-02-01'
@@ -139,7 +160,7 @@ effectiveEndDate: '2026-04-03'
 
 ## AoE Timezone
 
-All dates use **AoE (Anywhere on Earth)** timezone (UTC-12):
+Date-only values use **AoE (Anywhere on Earth)** timezone (UTC-12):
 
 | Date | AoE Time | UTC Equivalent |
 |------|----------|----------------|
@@ -147,6 +168,8 @@ All dates use **AoE (Anywhere on Earth)** timezone (UTC-12):
 | End: `'2026-04-01'` | 23:59:59 AoE Apr 1 | 11:59:59 UTC Apr 2 |
 
 This ensures applicants in any timezone have until the end of the stated day.
+
+ISO datetime values bypass AoE and are honored literally — use them only when a precise wall-clock close time is required (see Use Case 3).
 
 ## Type Definition
 
@@ -159,6 +182,7 @@ export interface RoundFrontmatter {
   tags: string[];
   heroImage: string;
   colorBrand: string;
+  // Dates accept "YYYY-MM-DD" (AoE) or any ISO datetime containing "T" (literal UTC instant)
   startDate: string;              // Required - display
   endDate: string;                // Required - display
   effectiveStartDate?: string;    // Optional - override
@@ -200,6 +224,7 @@ Covers:
 - AoE timezone conversion boundaries
 - Status computation for all states
 - Effective date override behavior
+- ISO datetime format (precise UTC close, non-UTC offsets, mixed date/datetime)
 - Edge cases (single-day rounds, year boundaries)
 
 ## Summary

--- a/docs/solutions/architecture/mdx-grant-round-landing-pages.md
+++ b/docs/solutions/architecture/mdx-grant-round-landing-pages.md
@@ -231,8 +231,8 @@ TypeScript won't catch missing fields because `gray-matter` returns untyped data
 | `tags` | Yes | Array matching Salesforce `Tags__c` |
 | `heroImage` | Yes | Path to public image |
 | `colorBrand` | Yes | Must exist in theme colors |
-| `startDate` | Yes | ISO format `YYYY-MM-DD` |
-| `endDate` | Yes | ISO format `YYYY-MM-DD` |
+| `startDate` | Yes | `YYYY-MM-DD` (AoE) or ISO datetime with `T` (literal UTC). See `grant-round-date-fields-20260203.md`. |
+| `endDate` | Yes | `YYYY-MM-DD` (AoE) or ISO datetime with `T` (literal UTC). See `grant-round-date-fields-20260203.md`. |
 
 ### 2. Hero Images Require Manual Registration
 

--- a/src/__tests__/lib/rounds.test.ts
+++ b/src/__tests__/lib/rounds.test.ts
@@ -123,6 +123,59 @@ describe('computeRoundStatus', () => {
     });
   });
 
+  describe('ISO datetime format', () => {
+    const startDate = '2026-02-02';
+    const endDate = '2026-04-01';
+
+    it('should treat effectiveEndDate with ISO datetime as a literal UTC instant', () => {
+      // Grace period closing at 01:00:00 UTC on Apr 24th, not AoE end-of-day
+      const effectiveEndDate = '2026-04-24T01:00:00Z';
+
+      // 1 second before close
+      mockCurrentTime('2026-04-24T00:59:59Z');
+      expect(computeRoundStatus(startDate, endDate, undefined, effectiveEndDate)).toBe('active');
+
+      // 1 second after close
+      mockCurrentTime('2026-04-24T01:00:01Z');
+      expect(computeRoundStatus(startDate, endDate, undefined, effectiveEndDate)).toBe('closed');
+    });
+
+    it('should treat effectiveStartDate with ISO datetime as a literal UTC instant', () => {
+      const effectiveStartDate = '2026-02-02T09:30:00Z';
+
+      // Before the precise start instant
+      mockCurrentTime('2026-02-02T09:29:59Z');
+      expect(computeRoundStatus(startDate, endDate, effectiveStartDate)).toBe('upcoming');
+
+      // At the precise start instant
+      mockCurrentTime('2026-02-02T09:30:00Z');
+      expect(computeRoundStatus(startDate, endDate, effectiveStartDate)).toBe('active');
+    });
+
+    it('should honour timezone offsets in ISO datetimes', () => {
+      // 01:00 -05:00 == 06:00 UTC
+      const effectiveEndDate = '2026-04-24T01:00:00-05:00';
+
+      mockCurrentTime('2026-04-24T05:59:59Z');
+      expect(computeRoundStatus(startDate, endDate, undefined, effectiveEndDate)).toBe('active');
+
+      mockCurrentTime('2026-04-24T06:00:01Z');
+      expect(computeRoundStatus(startDate, endDate, undefined, effectiveEndDate)).toBe('closed');
+    });
+
+    it('should allow mixing date-only display dates with ISO datetime effective dates', () => {
+      // Public endDate is a date (AoE), grace period overrides with precise UTC instant
+      const effectiveEndDate = '2026-04-02T03:00:00Z';
+
+      // Past the date-only AoE close (11:59 UTC Apr 2nd), still before effective instant
+      mockCurrentTime('2026-04-02T02:59:59Z');
+      expect(computeRoundStatus(startDate, endDate, undefined, effectiveEndDate)).toBe('active');
+
+      mockCurrentTime('2026-04-02T03:00:01Z');
+      expect(computeRoundStatus(startDate, endDate, undefined, effectiveEndDate)).toBe('closed');
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle same start and end date (single day round)', () => {
       const singleDay = '2026-03-15';

--- a/src/lib/rounds/index.ts
+++ b/src/lib/rounds/index.ts
@@ -8,14 +8,23 @@ const ROUNDS_DIRECTORY = path.join(process.cwd(), 'content/rounds');
 export type RoundStatus = 'active' | 'closed' | 'upcoming';
 
 /**
- * Convert a date string to AoE (Anywhere on Earth) timestamp.
- * AoE is UTC-12, the last timezone on Earth.
- * @param dateStr - Date in YYYY-MM-DD format
- * @param startOfDay - If true, returns 00:00:00 AoE; if false, returns 23:59:59 AoE
+ * Resolve a round date string to a UTC epoch-ms.
+ *
+ * Accepts two formats:
+ *   - Date only `YYYY-MM-DD`: interpreted in AoE (UTC-12) as either
+ *     00:00:00 (startOfDay=true) or 23:59:59 (startOfDay=false).
+ *   - Full ISO datetime containing `T` (e.g. `2026-04-24T01:00:00Z`):
+ *     parsed literally. AoE and `startOfDay` are ignored.
+ *
+ * Use the datetime form when a specific wall-clock close time is needed
+ * (e.g. a short grace period that does not align to AoE day boundaries).
  */
-function toAoETimestamp(dateStr: string, startOfDay: boolean): number {
+function resolveRoundTimestamp(value: string, startOfDay: boolean): number {
+  if (value.includes('T')) {
+    return new Date(value).getTime();
+  }
   const time = startOfDay ? '00:00:00' : '23:59:59';
-  return new Date(`${dateStr}T${time}-12:00`).getTime();
+  return new Date(`${value}T${time}-12:00`).getTime();
 }
 
 /**
@@ -29,11 +38,11 @@ export function computeRoundStatus(
   effectiveEndDate?: string
 ): RoundStatus {
   const now = Date.now();
-  const startAoE = toAoETimestamp(effectiveStartDate || startDate, true);
-  const endAoE = toAoETimestamp(effectiveEndDate || endDate, false);
+  const start = resolveRoundTimestamp(effectiveStartDate || startDate, true);
+  const end = resolveRoundTimestamp(effectiveEndDate || endDate, false);
 
-  if (now < startAoE) return 'upcoming';
-  if (now > endAoE) return 'closed';
+  if (now < start) return 'upcoming';
+  if (now > end) return 'closed';
   return 'active';
 }
 


### PR DESCRIPTION
## Summary

ESP requested leaving the PhD Fellowship application open ~12 hours past the April 22nd public deadline to accept last-minute submissions — specifically, close around **01:00 UTC on April 24th**.

Achieving that precise close time required two pieces:

1. **Datetime support in round dates.** Previously `toAoETimestamp` only accepted `YYYY-MM-DD` and forced close times to 23:59 AoE (11:59 UTC next day). Renamed to `resolveRoundTimestamp` and extended so any value containing `T` is parsed as a literal ISO datetime. Date-only values keep existing AoE semantics → fully backwards compatible.
2. **Grace period for PhDFP.** `effectiveEndDate: '2026-04-24T01:00:00Z'` on `content/rounds/phdfp26.mdx`. Public `endDate` stays `2026-04-22`, so hero / description / Deadline section still display April 22nd — the submission form quietly stays open until the precise instant.

## Files

- `src/lib/rounds/index.ts` — rename + extend the timestamp resolver, update `computeRoundStatus` to use it.
- `content/rounds/phdfp26.mdx` — `effectiveEndDate` set to ISO datetime.
- `src/__tests__/lib/rounds.test.ts` — 4 new tests covering the datetime path (precise end, precise start, non-UTC offsets, mixing date-only public dates with datetime effective dates). All 15 tests pass.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npx vitest run src/__tests__/lib/rounds.test.ts` — 15/15 passing
- [x] Verify `/rounds/phdfp26` shows status `active` through 2026-04-24 01:00 UTC, then `closed` at 01:00:01 UTC
- [x] Verify hero / description / Deadline section still display **April 22nd, 2026**
- [x] Confirm form submission works during the grace window