### PR TITLE
Remove network selection from Grantee Finance form, default to Ethereum Mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@adraffy/ens-normalize": "^1.11.0",
     "@chakra-ui/checkbox": "^1.7.1",
     "@chakra-ui/icons": "^1.1.1",
     "@chakra-ui/image": "^1.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@adraffy/ens-normalize':
+        specifier: ^1.11.0
+        version: 1.11.1
       '@chakra-ui/checkbox':
         specifier: ^1.7.1
         version: 1.7.1(@chakra-ui/system@1.12.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(react@18.3.1))(framer-motion@11.18.2(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)

--- a/src/components/forms/GranteeFinanceForm.tsx
+++ b/src/components/forms/GranteeFinanceForm.tsx
@@ -34,7 +34,7 @@ import {
 import { chakraStyles } from './selectStyles';
 
 import { GranteeFinanceFormData, PaymentPreference } from '../../types';
-import { TOKEN_OPTIONS, NETWORK_OPTIONS } from './constants';
+import { TOKEN_OPTIONS } from './constants';
 
 export const GranteeFinanceForm: FC = () => {
   const [paymentPreference, setPaymentPreference] = useState<PaymentPreference>('');
@@ -147,8 +147,7 @@ export const GranteeFinanceForm: FC = () => {
                       walletAddress: '',
                       walletAddressResolved: '',
                       walletAddressInputType: '',
-                      token: '',
-                      network: ''
+                      token: ''
                     });
                   }}
                   value={value}
@@ -165,6 +164,13 @@ export const GranteeFinanceForm: FC = () => {
                     </Radio>
                   </Stack>
                 </RadioGroup>
+
+                {receivesCrypto && (
+                  <PageText as='small' fontSize='helpText' color='brand.orange.100' mt={3}>
+                    <strong>Please note:</strong> All cryptocurrency transactions are processed
+                    exclusively on the Ethereum Mainnet.
+                  </PageText>
+                )}
               </FormControl>
             )}
           />
@@ -292,52 +298,6 @@ export const GranteeFinanceForm: FC = () => {
                       <Box mt={1}>
                         <PageText as='small' fontSize='helpText' color='red.500'>
                           Token selection is required.
-                        </PageText>
-                      </Box>
-                    )}
-                  </FormControl>
-                )}
-              />
-
-              <Controller
-                name='network'
-                control={control}
-                rules={{
-                  required: receivesCrypto,
-                  validate: value => !receivesCrypto || value !== ''
-                }}
-                defaultValue=''
-                render={({ field: { onChange }, fieldState: { error } }) => (
-                  <FormControl id='network-control' isRequired={receivesCrypto} mb={8}>
-                    <FormLabel htmlFor='network' mb={1}>
-                      <PageText display='inline' fontSize='input'>
-                        Network
-                      </PageText>
-                    </FormLabel>
-
-                    <PageText as='small' fontSize='helpText' color='brand.helpText'>
-                      Select the network on which you would like to receive payment.
-                    </PageText>
-
-                    <Box mt={3}>
-                      <Select
-                        id='network'
-                        options={NETWORK_OPTIONS}
-                        onChange={option =>
-                          onChange((option as (typeof NETWORK_OPTIONS)[number]).value)
-                        }
-                        components={{ DropdownIndicator }}
-                        placeholder='Select network'
-                        closeMenuOnSelect={true}
-                        selectedOptionColor='brand.option'
-                        chakraStyles={chakraStyles}
-                      />
-                    </Box>
-
-                    {error && (
-                      <Box mt={1}>
-                        <PageText as='small' fontSize='helpText' color='red.500'>
-                          Network selection is required.
                         </PageText>
                       </Box>
                     )}

--- a/src/components/forms/constants.ts
+++ b/src/components/forms/constants.ts
@@ -182,12 +182,6 @@ export const TOKEN_OPTIONS = [
   { value: 'DAI', label: 'DAI' },
 ];
 
-export const NETWORK_OPTIONS = [
-  { value: 'Ethereum Mainnet', label: 'Ethereum Mainnet' },
-  { value: 'Arbitrum', label: 'Arbitrum' },
-  { value: 'Optimism', label: 'Optimism' },
-];
-
 // countries
 export const COUNTRY_OPTIONS = [
   {

--- a/src/lib/ens.ts
+++ b/src/lib/ens.ts
@@ -7,7 +7,12 @@ import {
   type Address,
 } from 'viem';
 import { mainnet } from 'viem/chains';
-import { normalize } from 'viem/ens';
+// Imported directly from @adraffy/ens-normalize (rather than via viem/ens) to
+// work around a Next 15 SWC minifier bug that inlines the viem wrapper chain
+// — `viem/ens.normalize` → `ox/Ens.normalize` (namespace import) → `ens_normalize`
+// — to `undefined`, causing ENS resolution to fetch /resolve/undefined and
+// downstream "Cannot read properties of undefined (reading 'replace')" errors.
+import { ens_normalize as normalize } from '@adraffy/ens-normalize';
 
 // RPC fallback for when metadata API fails
 const transport = fallback([

--- a/src/pages/api/grantee-finance.ts
+++ b/src/pages/api/grantee-finance.ts
@@ -20,7 +20,6 @@ async function handler(req: GranteeFinanceNextApiRequest, res: NextApiResponse):
       walletAddressResolved,
       walletAddressInputType,
       token,
-      network,
       // Fiat fields
       beneficiaryAddress: Beneficiary_Address__c,
       fiatCurrencyCode: Fiat_Currency__c,
@@ -87,7 +86,7 @@ async function handler(req: GranteeFinanceNextApiRequest, res: NextApiResponse):
     if (verifiedAddress && token) {
       Contract_Wallet_Address__c = verifiedAddress;
       Contract_Token__c = token;
-      Contract_Network__c = network;
+      Contract_Network__c = 'Ethereum Mainnet';
 
       // Store original ENS name if user submitted an ENS, clear it if they switched to direct address
       if (walletAddressInputType === 'ens' && walletAddress) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,6 @@ export interface GranteeFinanceFormData extends CaptchaForm {
   walletAddressResolved: string; // SF API: Contract_Wallet_Address__c (verified hex address)
   walletAddressInputType: 'address' | 'ens' | ''; // Used to determine if ENS__c should be populated
   token: TokenPreference | ''; // SF API: Contract_Token__c (ETH or DAI)
-  network: string; // SF API: Contract_Network__c (Ethereum Mainnet, Arbitrum, Optimism)
   isCentralizedExchange: string; // SF API: Centralized_Exchange_Address__c
 
   // FIAT
@@ -330,7 +329,6 @@ export interface GranteeFinanceNextApiRequest extends NextApiRequest {
     walletAddressResolved: string;
     walletAddressInputType: 'address' | 'ens' | '';
     token: 'ETH' | 'DAI' | '';
-    network: string;
     // Fiat fields
     beneficiaryAddress: string;
     fiatCurrencyCode: string;


### PR DESCRIPTION
Closes #525

## Summary
- Removed the Network select field from the Grantee Finance form (no more Arbitrum / Optimism options).
- Added an inline note under the Payment Preference radios — shown only when "Receive Cryptocurrency" is selected — stating that all crypto transactions are processed exclusively on Ethereum Mainnet.
- Hardcoded `Contract_Network__c = 'Ethereum Mainnet'` server-side so Salesforce records stay accurate without trusting client input.
- Dropped the now-unused `network` field from `GranteeFinanceFormData` / `GranteeFinanceNextApiRequest` and the `NETWORK_OPTIONS` constant.

## Test plan
- [x] Visit `/applicants/grantee-finance`, select **Receive Cryptocurrency**, confirm the mainnet notice appears directly under the radio buttons in brand orange.
- [x] Select **Receive Fiat**, confirm the notice does not appear.
- [x] Submit a valid crypto application against a test Contract ID and verify the `Contract_Network__c` field in Salesforce is set to `Ethereum Mainnet`.
- [x] Confirm `npm run type-check` and `npm run lint` pass.