### PR TITLE
feat: add City field to RFP, Wishlist, and Direct Grant forms

### DIFF
--- a/src/components/forms/RFPForm.tsx
+++ b/src/components/forms/RFPForm.tsx
@@ -4,7 +4,13 @@ import { BaseGrantForm } from './BaseGrantForm';
 import { RFP_THANK_YOU_PAGE_URL } from '../../constants';
 import { api } from './api';
 import { FormConfig } from './schemas/BaseGrant';
-import { RFPSchema, RFPItem, RFPData } from './schemas/RFP';
+import {
+  RFPSchema,
+  RFPCommunityHubsSchema,
+  COMMUNITY_HUBS_RFP_SLUG,
+  RFPItem,
+  RFPData
+} from './schemas/RFP';
 import {
   ContactInformationSection,
   FormContainer,
@@ -28,10 +34,12 @@ const rfpFormConfig: FormConfig = {
 };
 
 export const RFPForm: FC<RFPFormProps> = ({ rfpItem }) => {
+  const isCommunityHubs = rfpItem.Custom_URL_Slug__c === COMMUNITY_HUBS_RFP_SLUG;
+
   return (
     <BaseGrantForm<RFPData>
       config={rfpFormConfig}
-      schema={RFPSchema}
+      schema={isCommunityHubs ? RFPCommunityHubsSchema : RFPSchema}
       selectedItem={rfpItem}
       onSubmit={api.rfp.submit}
     >
@@ -41,7 +49,12 @@ export const RFPForm: FC<RFPFormProps> = ({ rfpItem }) => {
           displayText={rfpFormConfig.selectedItemDisplayText}
         />
 
-        <ContactInformationSection fields={{ applicantProfile: false }} />
+        <ContactInformationSection
+          fields={{
+            applicantProfile: false,
+            ...(isCommunityHubs && { city: { isRequired: true } })
+          }}
+        />
 
         <ProjectOverviewSection />
 

--- a/src/components/forms/schemas/BaseGrant.ts
+++ b/src/components/forms/schemas/BaseGrant.ts
@@ -29,6 +29,7 @@ const contactInformationSchema = {
     .url({ message: 'Invalid URL' })
     .optional()
     .or(z.literal('')),
+  city: stringFieldSchema('City', { max: MAX_TEXT_LENGTH }).optional().or(z.literal('')),
   country: stringFieldSchema('Country', { min: 1, max: 2 }), // 2 character country code
   timezone: stringFieldSchema('Time zone', { min: 1 })
 };

--- a/src/components/forms/schemas/RFP.ts
+++ b/src/components/forms/schemas/RFP.ts
@@ -28,6 +28,14 @@ export const RFPSchema = z.object({
   ...paymentAcknowledgementSchema
 });
 
+// Custom URL slug of the RFP item whose application form requires the City field.
+export const COMMUNITY_HUBS_RFP_SLUG = 'community-hubs';
+
+// Community Hubs applications require the City field, so override it to be required.
+export const RFPCommunityHubsSchema = RFPSchema.extend({
+  city: stringFieldSchema('City', { min: 1, max: MAX_TEXT_LENGTH })
+});
+
 export type RFPData = z.infer<typeof RFPSchema>;
 
 export interface RFPItem {

--- a/src/components/forms/sections/ContactInformationSection.tsx
+++ b/src/components/forms/sections/ContactInformationSection.tsx
@@ -26,6 +26,7 @@ interface ContactInformationSectionProps {
     otherProfileType?: FieldConfig | false;
     alternativeContact?: FieldConfig | false;
     website?: FieldConfig | false;
+    city?: FieldConfig | false;
     country?: FieldConfig | false;
     timezone?: FieldConfig | false;
     applicantProfile?: FieldConfig | false;
@@ -66,6 +67,10 @@ const DEFAULT_FIELDS = {
   },
   website: {
     label: 'Website',
+    isRequired: false
+  },
+  city: {
+    label: 'City',
     isRequired: false
   },
   country: {
@@ -120,6 +125,9 @@ export const ContactInformationSection: FC<ContactInformationSectionProps> = ({ 
 
   const websiteConfig =
     fields?.website === false ? null : { ...DEFAULT_FIELDS.website, ...fields?.website };
+
+  const cityConfig =
+    fields?.city === false ? null : { ...DEFAULT_FIELDS.city, ...fields?.city };
 
   const countryConfig =
     fields?.country === false ? null : { ...DEFAULT_FIELDS.country, ...fields?.country };
@@ -229,6 +237,15 @@ export const ContactInformationSection: FC<ContactInformationSectionProps> = ({ 
           label={websiteConfig.label}
           helpText={websiteConfig.helpText}
           isRequired={websiteConfig.isRequired}
+        />
+      )}
+
+      {cityConfig && (
+        <TextField
+          id='city'
+          label={cityConfig.label}
+          helpText={cityConfig.helpText}
+          isRequired={cityConfig.isRequired}
         />
       )}
 

--- a/src/lib/sf-field-mappings.ts
+++ b/src/lib/sf-field-mappings.ts
@@ -82,6 +82,7 @@ const rfpMapping = createTypedMapping<RFPData>({
   otherProfileType: 'Application_Other_ProfileType__c',
   alternativeContact: 'Application_Alternative_Contact__c',
   website: 'Application_Website__c',
+  city: 'Application_City__c',
   country: 'Application_Country__c',
   timezone: 'Application_Time_Zone__c',
 
@@ -117,6 +118,7 @@ const directGrantMapping = createTypedMapping<DirectGrantData>({
   otherProfileType: 'Application_Other_ProfileType__c',
   alternativeContact: 'Application_Alternative_Contact__c',
   website: 'Application_Website__c',
+  city: 'Application_City__c',
   country: 'Application_Country__c',
   timezone: 'Application_Time_Zone__c',
   applicantProfile: 'Application_Profile__c',
@@ -161,6 +163,7 @@ const wishlistMapping = createTypedMapping<WishlistData>({
   otherProfileType: 'Application_Other_ProfileType__c',
   alternativeContact: 'Application_Alternative_Contact__c',
   website: 'Application_Website__c',
+  city: 'Application_City__c',
   country: 'Application_Country__c',
   timezone: 'Application_Time_Zone__c',
   applicantProfile: 'Application_Profile__c',


### PR DESCRIPTION
## Summary

Implements #538 — adds an optional **City** text field to the standard application webforms (RFP, Wishlist, Direct Grant).

- Open text field rendered **before** Country and Time Zone in the Contact Information section
- Maps to the Salesforce **`Application_City__c`** field (Text Area 255)
- Optional by default across all three forms
- **Required** on the Community Hubs RFP application (`/rfp/community-hubs/apply`) via a dedicated `RFPCommunityHubsSchema` variant selected by the item's `Custom_URL_Slug__c`

## Changes

- `schemas/BaseGrant.ts` — add optional `city` to the shared `contactInformationSchema` (flows into RFP/Wishlist/Direct Grant; Office Hours uses its own contact schema and is unaffected)
- `sections/ContactInformationSection.tsx` — render the `city` `TextField` before the Country/Time Zone row, with field-config/override support (`isRequired` default `false`)
- `schemas/RFP.ts` — add `RFPCommunityHubsSchema` (city required) and the `COMMUNITY_HUBS_RFP_SLUG` constant
- `RFPForm.tsx` — switch to the community-hubs schema and mark city required when the RFP item is Community Hubs
- `lib/sf-field-mappings.ts` — map `city → Application_City__c` for the rfp, directGrant, and wishlist mappings (enforced at compile time by `createTypedMapping`)

## Testing

- `npm run type-check` ✅
- `npm run lint` ✅ (no warnings/errors)
- `sf-field-mappings` unit tests ✅ (30 passed)
- Drove the real `/api/direct-grant` handler locally with the exact client multipart payload. Confirmed: an empty City is received and mapped to `Application_City__c: ""` (consistent with the existing optional `website` field); a filled City maps through correctly.

Closes #538