### PR TITLE
fix: self-heal ISR 404s on RFP/Wishlist detail & apply pages

### DIFF
--- a/src/pages/applicants/rfp/[item]/apply.tsx
+++ b/src/pages/applicants/rfp/[item]/apply.tsx
@@ -68,7 +68,9 @@ export const getStaticProps: GetStaticProps<RFPItemApplyProps> = async ({ params
 
   if (!rfpItem) {
     return {
-      notFound: true
+      notFound: true,
+      // Self-heal a stale 404; without revalidate Next.js caches it until redeploy.
+      revalidate: 60
     };
   }
 

--- a/src/pages/applicants/rfp/[item]/index.tsx
+++ b/src/pages/applicants/rfp/[item]/index.tsx
@@ -195,7 +195,9 @@ export const getStaticProps: GetStaticProps<RFPItemApplyProps> = async ({ params
 
   if (!rfpItem) {
     return {
-      notFound: true
+      notFound: true,
+      // Self-heal a stale 404; without revalidate Next.js caches it until redeploy.
+      revalidate: 60
     };
   }
 

--- a/src/pages/applicants/wishlist/[item]/apply.tsx
+++ b/src/pages/applicants/wishlist/[item]/apply.tsx
@@ -69,7 +69,9 @@ export const getStaticProps: GetStaticProps<WishlistItemApplyProps> = async ({ p
 
   if (!wishlistItem) {
     return {
-      notFound: true
+      notFound: true,
+      // Self-heal a stale 404; without revalidate Next.js caches it until redeploy.
+      revalidate: 60
     };
   }
 

--- a/src/pages/applicants/wishlist/[item]/index.tsx
+++ b/src/pages/applicants/wishlist/[item]/index.tsx
@@ -143,7 +143,9 @@ export const getStaticProps: GetStaticProps<WishlistItemApplyProps> = async ({ p
 
   if (!wishlistItem) {
     return {
-      notFound: true
+      notFound: true,
+      // Self-heal a stale 404; without revalidate Next.js caches it until redeploy.
+      revalidate: 60
     };
   }
 


### PR DESCRIPTION
## Problem

Colleagues activate an RFP/Wishlist item in Salesforce; the **list** page at `/applicants/rfp` updates correctly (ISR), but clicking through to an item like `/applicants/rfp/rtd8_india_academic` returns the **404 page**. Recurring bug.

## Root cause

The four dynamic pages (`rfp/[item]/index`, `rfp/[item]/apply`, `wishlist/[item]/index`, `wishlist/[item]/apply`) all return `{ notFound: true }` from `getStaticProps` **without a `revalidate` field**. In Next.js ISR, a `notFound` returned without `revalidate` is cached permanently (until redeploy) — it never regenerates.

`fallback: 'blocking'` generates a brand-new slug fine on first request. But if a slug's 404 was ever cached — e.g. the URL was hit before the item was flipped to `Active` in Salesforce, or by a crawler/preview — that negative result sticks. The list keeps refreshing hourly (it has `revalidate: 3600`), so the item shows there, while the detail page serves the stale 404.

The reported URL uses the **slug** (not the SF Id), which only comes from the list's link — proving `Custom_URL_Slug__c` is populated and a fresh `getStaticProps` run *would* match. Confirms this is a stale negative cache, not a data-matching failure.

## Fix

Add `revalidate: 60` to all four `notFound` branches so a stale 404 self-heals within ~60s of the next request once the item is Active. Content (found) pages keep their existing `revalidate: 3600`.

## Verification

- `npm run type-check` passes.